### PR TITLE
Fix for array bounds issue for hydraulic conductivity in var_derive.f90.

### DIFF
--- a/build/source/engine/var_derive.f90
+++ b/build/source/engine/var_derive.f90
@@ -343,14 +343,14 @@ contains
   end select
 
   ! check that the hydraulic conductivity for macropores is greater than for micropores
-  if(iLayer > 0)then
+  if (iLayer > nSnow) then
    if( mLayerSatHydCondMP(iLayer-nSnow) < mLayerSatHydCond(iLayer-nSnow) )then
     write(*,'(2(a,e12.6),a,i0)')trim(message)//'WARNING: hydraulic conductivity for macropores [', mLayerSatHydCondMP(iLayer-nSnow), &
                                                '] is less than the hydraulic conductivity for micropores [', mLayerSatHydCond(iLayer-nSnow), &
                                                ']: resetting macropore conductivity to equal micropore value. Layer = ', iLayer
     mLayerSatHydCondMP(iLayer-nSnow) = mLayerSatHydCond(iLayer-nSnow)
    endif  ! if mLayerSatHydCondMP < mLayerSatHydCond
-  endif  ! if iLayer>0
+  end if ! if iLayer > nSnow
  end do  ! looping through soil layers
 
  end associate


### PR DESCRIPTION
Hi @ashleymedin - This PR fixes an array going out of bounds in var_derive.f90. Specifically, mLayerSatHydCondMP was going out of bounds for iLayer=nSnow around line 347. In this update, a surrounding if statement has been updated to resolve the issue.

With this update, BE_Debug now runs the laugh tests without detecting any segmentation faults or array bounds violations. Stack memory is no longer being corrupted by invalid array element access.

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] closes #xxx (identify the issue associated with this PR)
- [x] tests passed
- [ ] new tests added
- [ ] science test figures
- [ ] checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] ReleaseNotes entry
