### PR TITLE
Updates to link steps and Intel oneMKL builds on PC

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -101,17 +101,18 @@ endif()
 #=========================================================================================
 
 # Set compiler flags
+set(FLAGS_OPT $ENV{FLAGS_OPT}) # get optional user-specified flags from environment variables
 if(CMAKE_BUILD_TYPE MATCHES Debug)
     message("\nSetting Debug Options")
     add_compile_definitions(DEBUG)
-    set(FLAGS_NOAH -g -O0 -fbacktrace -fbounds-check -ffree-form -ffree-line-length-none -fmax-errors=0 -fPIC -Wfatal-errors)
-    set(FLAGS_ALL  -g -O0 -fbacktrace -fbounds-check -ffree-line-length-none -fmax-errors=0 -fPIC -Wfatal-errors -cpp)
-    set(FLAGS_CXX  -g -O0 -fbacktrace -fbounds-check -Wfatal-errors -std=c++17)
+    set(FLAGS_NOAH -g -O0 -fbacktrace -fbounds-check -ffree-form -ffree-line-length-none -fmax-errors=0 -fPIC -Wfatal-errors ${FLAGS_OPT})
+    set(FLAGS_ALL  -g -O0 -fbacktrace -fbounds-check -ffree-line-length-none -fmax-errors=0 -fPIC -Wfatal-errors -cpp ${FLAGS_OPT})
+    set(FLAGS_CXX  -g -O0 -fbacktrace -fbounds-check -Wfatal-errors -std=c++17 ${FLAGS_OPT})
 else()
     message("\nSetting Release Options")
-    set(FLAGS_NOAH -O3 -flto=1 -fuse-linker-plugin -ffree-form -ffree-line-length-none -fmax-errors=0 -fPIC -Wfatal-errors)
-    set(FLAGS_ALL  -O3 -flto=1 -fuse-linker-plugin -ffree-line-length-none -fmax-errors=0 -fPIC -Wfatal-errors -cpp)
-    set(FLAGS_CXX  -O3 -flto=1 -fuse-linker-plugin -Wfatal-errors -std=c++17)
+    set(FLAGS_NOAH -O3 -flto=1 -fuse-linker-plugin -ffree-form -ffree-line-length-none -fmax-errors=0 -fPIC -Wfatal-errors ${FLAGS_OPT})
+    set(FLAGS_ALL  -O3 -flto=1 -fuse-linker-plugin -ffree-line-length-none -fmax-errors=0 -fPIC -Wfatal-errors -cpp ${FLAGS_OPT})
+    set(FLAGS_CXX  -O3 -flto=1 -fuse-linker-plugin -Wfatal-errors -std=c++17 ${FLAGS_OPT})
 endif()
 
 # Find Sundials if exists, add path here if FATAL_ERROR "Did not find Sundials directory"
@@ -542,9 +543,7 @@ target_compile_options(SUMMA_NOAHMP PRIVATE ${FLAGS_NOAH})
 add_library(SUMMA_COMM OBJECT ${COMM_ALL})
 target_compile_options(SUMMA_COMM PRIVATE ${FLAGS_ALL})
 target_include_directories(SUMMA_COMM PRIVATE ${INCLUDES})
-#target_link_libraries(SUMMA_COMM PUBLIC SUMMA_NOAHMP) #OG
-target_link_libraries(SUMMA_COMM PUBLIC SUMMA_NOAHMP ${FLAGS_ALL}) #SJT
-#target_link_options(SUMMA_COMM PUBLIC ${FLAGS_ALL}) #SJT
+target_link_libraries(SUMMA_COMM PUBLIC SUMMA_NOAHMP ${FLAGS_ALL}) # added flags to the link step 
 
 # For NexGen, build SUMMA Shared Library and add the outside BMI libraries
 if(CMAKE_BUILD_TYPE MATCHES NexGen)
@@ -609,14 +608,10 @@ else()
         target_link_libraries(summa PUBLIC ${LIBRARIES} ${LIB_SUNDIALS} SUMMA_NOAHMP SUMMA_COMM)
     else()
         target_include_directories(summa PUBLIC ${INCLUDES})
-	#target_link_libraries(summa PUBLIC ${LIBRARIES} SUMMA_NOAHMP SUMMA_COMM) #OG
-	target_link_libraries(summa PUBLIC ${LIBRARIES} SUMMA_NOAHMP SUMMA_COMM ${FLAGS_ALL}) #SJT
-	#target_link_options(summa PUBLIC ${FLAGS_ALL}) #SJT
+	target_link_libraries(summa PUBLIC ${LIBRARIES} SUMMA_NOAHMP SUMMA_COMM ${FLAGS_ALL}) # added flags to the link step
     endif()
 
     add_executable(${EXEC_NAME} ${MAIN_SUMMA})
     set_property(TARGET ${EXEC_NAME} PROPERTY LINKER_LANGUAGE Fortran)
-    #target_link_libraries(${EXEC_NAME} summa) #OG
-    target_link_libraries(${EXEC_NAME} summa ${FLAGS_ALL}) #SJT
-    #target_link_options(${EXEC_NAME} PUBLIC ${FLAGS_ALL}) #SJT
+    target_link_libraries(${EXEC_NAME} summa ${FLAGS_ALL}) # added flags to the link step
 endif()

--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -104,14 +104,14 @@ endif()
 if(CMAKE_BUILD_TYPE MATCHES Debug)
     message("\nSetting Debug Options")
     add_compile_definitions(DEBUG)
-    set(FLAGS_NOAH -g -O0 -fbounds-check -ffree-form -ffree-line-length-none -fmax-errors=0 -fPIC -Wfatal-errors)
-    set(FLAGS_ALL  -g -O0 -fbounds-check -ffree-line-length-none -fmax-errors=0 -fPIC -Wfatal-errors -cpp)
-    set(FLAGS_CXX  -g -O0 -fbounds-check -Wfatal-errors -std=c++17)
+    set(FLAGS_NOAH -g -O0 -fbacktrace -fbounds-check -ffree-form -ffree-line-length-none -fmax-errors=0 -fPIC -Wfatal-errors)
+    set(FLAGS_ALL  -g -O0 -fbacktrace -fbounds-check -ffree-line-length-none -fmax-errors=0 -fPIC -Wfatal-errors -cpp)
+    set(FLAGS_CXX  -g -O0 -fbacktrace -fbounds-check -Wfatal-errors -std=c++17)
 else()
     message("\nSetting Release Options")
-    set(FLAGS_NOAH -O3 -flto -ffree-form -ffree-line-length-none -fmax-errors=0 -fPIC -Wfatal-errors)
-    set(FLAGS_ALL  -O3 -flto -ffree-line-length-none -fmax-errors=0 -fPIC -Wfatal-errors -cpp)
-    set(FLAGS_CXX  -O3 -flto -Wfatal-errors -std=c++17)
+    set(FLAGS_NOAH -O3 -flto=1 -fuse-linker-plugin -ffree-form -ffree-line-length-none -fmax-errors=0 -fPIC -Wfatal-errors)
+    set(FLAGS_ALL  -O3 -flto=1 -fuse-linker-plugin -ffree-line-length-none -fmax-errors=0 -fPIC -Wfatal-errors -cpp)
+    set(FLAGS_CXX  -O3 -flto=1 -fuse-linker-plugin -Wfatal-errors -std=c++17)
 endif()
 
 # Find Sundials if exists, add path here if FATAL_ERROR "Did not find Sundials directory"
@@ -542,7 +542,9 @@ target_compile_options(SUMMA_NOAHMP PRIVATE ${FLAGS_NOAH})
 add_library(SUMMA_COMM OBJECT ${COMM_ALL})
 target_compile_options(SUMMA_COMM PRIVATE ${FLAGS_ALL})
 target_include_directories(SUMMA_COMM PRIVATE ${INCLUDES})
-target_link_libraries(SUMMA_COMM PUBLIC SUMMA_NOAHMP)
+#target_link_libraries(SUMMA_COMM PUBLIC SUMMA_NOAHMP) #OG
+target_link_libraries(SUMMA_COMM PUBLIC SUMMA_NOAHMP ${FLAGS_ALL}) #SJT
+#target_link_options(SUMMA_COMM PUBLIC ${FLAGS_ALL}) #SJT
 
 # For NexGen, build SUMMA Shared Library and add the outside BMI libraries
 if(CMAKE_BUILD_TYPE MATCHES NexGen)
@@ -607,10 +609,14 @@ else()
         target_link_libraries(summa PUBLIC ${LIBRARIES} ${LIB_SUNDIALS} SUMMA_NOAHMP SUMMA_COMM)
     else()
         target_include_directories(summa PUBLIC ${INCLUDES})
-        target_link_libraries(summa PUBLIC ${LIBRARIES} SUMMA_NOAHMP SUMMA_COMM)
+	#target_link_libraries(summa PUBLIC ${LIBRARIES} SUMMA_NOAHMP SUMMA_COMM) #OG
+	target_link_libraries(summa PUBLIC ${LIBRARIES} SUMMA_NOAHMP SUMMA_COMM ${FLAGS_ALL}) #SJT
+	#target_link_options(summa PUBLIC ${FLAGS_ALL}) #SJT
     endif()
 
     add_executable(${EXEC_NAME} ${MAIN_SUMMA})
     set_property(TARGET ${EXEC_NAME} PROPERTY LINKER_LANGUAGE Fortran)
-    target_link_libraries(${EXEC_NAME} summa)
+    #target_link_libraries(${EXEC_NAME} summa) #OG
+    target_link_libraries(${EXEC_NAME} summa ${FLAGS_ALL}) #SJT
+    #target_link_options(${EXEC_NAME} PUBLIC ${FLAGS_ALL}) #SJT
 endif()

--- a/build/cmake/build.pc.bash
+++ b/build/cmake/build.pc.bash
@@ -4,11 +4,11 @@
 # Environment variables that must be set for cmake: FC, LINK_DIRS, INCLUDES_DIRS, and LIBRARY_LINKS
 
 # PC Example using Ubuntu
-export FC=gfortran                                            # Fortran compiler family
-export LINK_DIRS=/usr/local/lib                               # Link directories for cmake
-export INCLUDES_DIRS='/usr/include;/usr/local/include'        # directories for INCLUDES cmake variable (cmake uses semicolons as separators)
-export LIBRARY_LINKS='-llapack;-lgfortran;-lnetcdff;-lnetcdf' # list of library links (cmake uses semicolons as separators)
+#export FC=gfortran                                            # Fortran compiler family
+#export LINK_DIRS=/usr/local/lib                               # Link directories for cmake
+#export INCLUDES_DIRS='/usr/include;/usr/local/include'        # directories for INCLUDES cmake variable (cmake uses semicolons as separators)
+#export LIBRARY_LINKS='-llapack;-lgfortran;-lnetcdff;-lnetcdf' # list of library links (cmake uses semicolons as separators)
 
-cmake -B ../cmake_build -S . -DCMAKE_BUILD_TYPE=BE_Debug
+cmake -B ../cmake_build -S . -DCMAKE_BUILD_TYPE=BE
 cmake --build ../cmake_build --target all
 

--- a/build/cmake/build.pc.bash
+++ b/build/cmake/build.pc.bash
@@ -1,14 +1,27 @@
 #!/bin/bash
 
-# build SUMMA on a PC using Bash, from cmake directory run this as ./build.pc.bash
+# Build SUMMA on a PC using Bash, from cmake directory run this as ./build.pc.bash
 # Environment variables that must be set for cmake: FC, LINK_DIRS, INCLUDES_DIRS, and LIBRARY_LINKS
+# Environment variables may be set within this script (see examples below) or in the terminal environment before executing this script
+# Actual settings may vary
 
-# PC Example using Ubuntu
+# PC Example using Ubuntu: LAPACK Builds
 #export FC=gfortran                                            # Fortran compiler family
 #export LINK_DIRS=/usr/local/lib                               # Link directories for cmake
-#export INCLUDES_DIRS='/usr/include;/usr/local/include'        # directories for INCLUDES cmake variable (cmake uses semicolons as separators)
-#export LIBRARY_LINKS='-llapack;-lgfortran;-lnetcdff;-lnetcdf' # list of library links (cmake uses semicolons as separators)
+#export INCLUDES_DIRS="/usr/include;/usr/local/include"        # directories for INCLUDES cmake variable (cmake uses semicolons as separators)
+#export LIBRARY_LINKS="-llapack;-lnetcdff;-lnetcdf"            # list of library links -- LAPACK builds
+#export FLAGS_OPT=""                                           # optional compiler flags -- LAPACK builds
 
+# PC Example using Ubuntu: Intel oneMKL builds (see https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl-link-line-advisor.html)
+#oneAPI_dir=/opt/intel/oneapi                                  # Intel oneAPI main directory
+#source $oneAPI_dir/setvars.sh                                 # initialize environment variables for Intel oneAPI
+#export FC=gfortran                                            # Fortran compiler family
+#export LINK_DIRS=/usr/local/lib                               # Link directories for cmake
+#export INCLUDES_DIRS="/usr/include;/usr/local/include"        # directories for INCLUDES cmake variable (cmake uses semicolons as separators)
+#export LIBRARY_LINKS="-lnetcdff;-lnetcdf;-Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_gf_lp64.a ${MKLROOT}/lib/intel64/libmkl_gnu_thread.a ${MKLROOT}/lib/intel64/libmkl_core.a -Wl,--end-group;-lgomp;-lpthread;-lm;-ldl"         # list of library links -- Intel oneMKL builds
+#export FLAGS_OPT="-m64;-I"${MKLROOT}/include""                # optional compiler flags -- Intel oneMKL builds
+
+# CMake Commands (build type controlled using DCMAKE_BUILD_TYPE)
 cmake -B ../cmake_build -S . -DCMAKE_BUILD_TYPE=BE
 cmake --build ../cmake_build --target all
 


### PR DESCRIPTION
Hey Ashley - This PR adds some new compiler flags for better debug info in case of seg faults and for improved link time optimization. Some flags have also been added to the link steps in CMakeLists.txt for runs on PC that do not use Actors or SUNDIALS. We can probably make similar additions for Actors/SUNDIALS, but I did not change those parts of CMakeLists.txt because I could not currently test them.

I have also updated build.pc.bash to include options for both LAPACK and Intel oneMKL. I had to import an additional environment variable into CMakeLists.txt to make it work. However, there is now the option of either package for the linear system solves on PC. On my system, oneMKL is over 20% faster. The output for LAPACK and oneMKL builds is identical for the laugh tests.

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] closes #xxx (identify the issue associated with this PR)
- [x] tests passed
- [ ] new tests added
- [ ] science test figures
- [ ] checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] ReleaseNotes entry
