### PR TITLE
Develop from ashely

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -311,23 +311,22 @@ set(NETCDF
     ${SUB_NETCDF_DIR}/def_output.f90
     ${SUB_NETCDF_DIR}/modelwrite.f90
     ${NETCDF_DIR}/netcdf_util.f90
-    ${SUB_NETCDF_DIR}/read_icond.f90)
+    ${NETCDF_DIR}/read_icond.f90)
 
 # Preliminary modules
 set(PRELIM
     ${ENGINE_DIR}/allocspace.f90
-    ${SUB_ENGINE_DIR}/check_icond.f90
+    ${ENGINE_DIR}/check_icond.f90
     ${ENGINE_DIR}/checkStruc.f90
     ${ENGINE_DIR}/childStruc.f90
     ${ENGINE_DIR}/conv_funcs.f90
     ${ENGINE_DIR}/convE2Temp.f90
     ${SUB_ENGINE_DIR}/ffile_info.f90
     ${ENGINE_DIR}/read_pinit.f90
-    ${SUB_ENGINE_DIR}/read_attrb.f90
+    ${ENGINE_DIR}/read_attrb.f90
     ${ENGINE_DIR}/paramCheck.f90
     ${ENGINE_DIR}/pOverwrite.f90
-    ${ENGINE_DIR}/sunGeomtry.f90)
-set(PRELIM_NOT_ACTORS
+    ${ENGINE_DIR}/sunGeomtry.f90
     ${ENGINE_DIR}/read_param.f90)
 
 # Model run support modules
@@ -413,10 +412,7 @@ set(INTERFACE
 set(FILE_ACCESS_INTERFACE
     ${FILE_ACCESS_DIR}/fortran_code/cppwrap_fileAccess.f90
     ${FILE_ACCESS_DIR}/fortran_code/output_structure.f90
-    ${FILE_ACCESS_DIR}/fortran_code/read_attrb.f90
     ${FILE_ACCESS_DIR}/fortran_code/read_force.f90
-    ${FILE_ACCESS_DIR}/fortran_code/read_icondFromStructure.f90
-    ${FILE_ACCESS_DIR}/fortran_code/read_param.f90
     ${FILE_ACCESS_DIR}/fortran_code/write_to_netcdf.f90
     ${FILE_ACCESS_DIR}/fortran_code/writeOutputFromOutputStructure.f90)
 set(JOB_INTERFACE

--- a/build/source/dshare/globalData.f90
+++ b/build/source/dshare/globalData.f90
@@ -271,8 +271,6 @@ MODULE globalData
   logical(lgt),allocatable,save,public           :: failedHRUs(:)                     ! list of true and false values to indicate if an HRU has failed
   type(ilength),allocatable,save,public          :: outputTimeStep(:)                 ! timestep in output files
   ! inital conditions for Actors
-  type(init_cond),allocatable,save,public        :: init_cond_prog(:)                 ! variable data for initial conditions
-  type(init_cond),allocatable,save,public        :: init_cond_bvar(:)                 ! variable data for initial conditions
 #else
   ! define metadata for model forcing datafile non-Actors
   type(file_info),save,public,allocatable        :: forcFileInfo(:)                   ! file info for model forcing data


### PR DESCRIPTION
Removed variables no longer used by Summa-Actors from globalData.f90:

Summa-Actors now uses the following files from the Summa Repo instead of its own:
- read_attrb.f90
- check_icond.f90
- read_icond.f90

