### PR TITLE
Add lookup variable for flux subroutines.

### DIFF
--- a/build/source/dshare/var_lookup.f90
+++ b/build/source/dshare/var_lookup.f90
@@ -835,6 +835,19 @@ MODULE var_lookup
  endtype iLook_vLookup
 
  ! ***********************************************************************************************************
+ ! (17) structure for looking up flux subroutines
+ ! ***********************************************************************************************************
+ type, public :: iLook_routine
+  integer(i4b)    :: vegNrgFlux = integerMissing ! vegNrgFlux
+  integer(i4b)    :: ssdNrgFlux = integerMissing ! ssdNrgFlux
+  integer(i4b)    :: vegLiqFlux = integerMissing ! vegLiqFlux
+  integer(i4b)    :: snowLiqFlx = integerMissing ! snowLiqFlx
+  integer(i4b)    :: soilLiqFlx = integerMissing ! soilLiqFlx
+  integer(i4b)    :: groundwatr = integerMissing ! groundwatr
+  integer(i4b)    :: bigAquifer = integerMissing ! bigAquifer
+ end type iLook_routine
+
+ ! ***********************************************************************************************************
  ! (X) define data structures and maximum number of variables of each type
  ! ***********************************************************************************************************
 
@@ -926,6 +939,8 @@ MODULE var_lookup
  type(iLook_freq),    public,parameter :: iLookFreq     =ilook_freq    (  1,  2,  3,  4)
  ! named variables in the lookup table structure
  type(iLook_vLookup), public,parameter :: iLookLOOKUP   =ilook_vLookup (  1,  2,  3)
+ ! named variables: flux subroutines
+ type(iLook_routine) ,public,parameter :: iLookROUTINE  =iLook_routine (  1,  2,  3,  4,  5,  6,  7)
  ! define maximum number of variables of each type
  integer(i4b),parameter,public :: maxvarDecisions = storage_size(iLookDECISIONS)/iLength
  integer(i4b),parameter,public :: maxvarTime      = storage_size(iLookTIME)/iLength


### PR DESCRIPTION
Hey Ashley - This PR adds a new lookup variable for flux subroutine names to var_lookup.f90. This variable will be used to reduce hard coded index values in future flux routine call related PRs. This update does not impact the results of the test suite, which has been confirmed on my machine.

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] closes #xxx (identify the issue associated with this PR)
- [x] tests passed
- [ ] new tests added
- [ ] science test figures
- [ ] checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] ReleaseNotes entry
