### PR TITLE
Shorten call syntax for vegLiqFlux and snowLiqFlx

### DIFF
--- a/build/source/dshare/data_types.f90
+++ b/build/source/dshare/data_types.f90
@@ -391,7 +391,28 @@ MODULE data_types
   real(rkind)              :: scalarThroughfallRainDeriv        ! intent(out): derivative in throughfall w.r.t. canopy liquid water (s-1)
   real(rkind)              :: scalarCanopyLiqDrainageDeriv      ! intent(out): derivative in canopy drainage w.r.t. canopy liquid water (s-1)
   integer(i4b)             :: err                               ! intent(out): error code
-  character(:),allocatable :: cmessage                          ! intent(out): error control
+  character(:),allocatable :: cmessage                          ! intent(out): error message
  end type out_type_vegLiqFlux
  ! ** end vegLiqFlux
+
+ ! ** snowLiqFlx
+ type, public :: in_type_snowLiqFlx ! derived type for intent(in) arguments in snowLiqFlx call
+  integer(i4b)             :: nSnow                             ! intent(in):    number of snow layers
+  logical(lgt)             :: firstFluxCall                     ! intent(in):    the first flux call (compute variables that are constant over the iterations)
+  logical(lgt)             :: scalarSolution                    ! intent(in):    flag to indicate the scalar solution
+  real(rkind)              :: scalarThroughfallRain             ! intent(in):    rain that reaches the snow surface without ever touching vegetation (kg m-2 s-1)
+  real(rkind)              :: scalarCanopyLiqDrainage           ! intent(in):    liquid drainage from the vegetation canopy (kg m-2 s-1)
+  real(rkind), allocatable :: mLayerVolFracLiqTrial(:)          ! intent(in):    trial value of volumetric fraction of liquid water at the current iteration (-)
+ end type in_type_snowLiqFlx
+
+ type, public :: io_type_snowLiqFlx ! derived type for intent(inout) arguments in snowLiqFlx call
+  real(rkind), allocatable :: iLayerLiqFluxSnow(:)              ! intent(inout): vertical liquid water flux at layer interfaces (m s-1)
+  real(rkind), allocatable :: iLayerLiqFluxSnowDeriv(:)         ! intent(inout): derivative in vertical liquid water flux at layer interfaces (m s-1)
+ end type io_type_snowLiqFlx
+
+ type, public :: out_type_snowLiqFlx ! derived type for intent(out) arguments in snowLiqFlx call
+  integer(i4b)             :: err                               ! intent(out):   error code
+  character(:),allocatable :: cmessage                          ! intent(out):   error message
+ end type out_type_snowLiqFlx
+ ! ** end snowLiqFlx
 END MODULE data_types


### PR DESCRIPTION
Hey @ashleymedin! This PR shortens the syntax for calls to the vegLiqFlux and snowLiqFlx subroutines in computFlux. This is the second part of the "length of a t-shirt" PR series. The output and resource use of the test suite (laugh + WRR tests) do not change with this update. 

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] closes #xxx (identify the issue associated with this PR)
- [x] tests passed
- [ ] new tests added
- [ ] science test figures
- [ ] checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] ReleaseNotes entry
