### PR TITLE
Reduce the call syntax length for groundwatr and bigAquifer

### DIFF
--- a/build/source/dshare/data_types.f90
+++ b/build/source/dshare/data_types.f90
@@ -422,13 +422,11 @@ MODULE data_types
   logical(lgt)             :: firstSplitOper                    ! intent(in):    flag indicating first flux call in a splitting operation
   logical(lgt)             :: scalarSolution                    ! intent(in):    flag to indicate the scalar solution
   logical(lgt)             :: deriv_desired                     ! intent(in):    flag indicating if derivatives are desired
-                      !! input: trial state variables
   real(rkind), allocatable :: mLayerTempTrial(:)                ! intent(in):    trial temperature at the current iteration (K)
   real(rkind), allocatable :: mLayerMatricHeadTrial(:)          ! intent(in):    matric potential (m)
   real(rkind), allocatable :: mLayerMatricHeadLiqTrial(:)       ! intent(in):    liquid water matric potential (m)
   real(rkind), allocatable :: mLayerVolFracLiqTrial(:)          ! intent(in):    volumetric fraction of liquid water (-)
   real(rkind), allocatable :: mLayerVolFracIceTrial(:)          ! intent(in):    volumetric fraction of ice (-)
-                      !! input: pre-computed deriavatives
   real(rkind), allocatable :: mLayerdTheta_dTk(:)               ! intent(in):    derivative in volumetric liquid water content w.r.t. temperature (K-1)
   real(rkind), allocatable :: dPsiLiq_dTemp(:)                  ! intent(in):    derivative in liquid water matric potential w.r.t. temperature (m K-1)
   real(rkind)              :: dCanopyTrans_dCanWat              ! intent(in):    derivative in canopy transpiration w.r.t. canopy total water content (s-1)
@@ -438,7 +436,6 @@ MODULE data_types
   real(rkind)              :: above_soilLiqFluxDeriv            ! intent(in):    derivative in layer above soil (canopy or snow) liquid flux w.r.t. liquid water
   real(rkind)              :: above_soildLiq_dTk                ! intent(in):    derivative of layer above soil (canopy or snow) liquid flux w.r.t. temperature
   real(rkind)              :: above_soilFracLiq                 ! intent(in):    fraction of liquid water layer above soil (canopy or snow) (-)
-                      !! input: fluxes
   real(rkind)              :: scalarCanopyTranspiration         ! intent(in):    canopy transpiration (kg m-2 s-1)
   real(rkind)              :: scalarGroundEvaporation           ! intent(in):    ground evaporation (kg m-2 s-1)
   real(rkind)              :: scalarRainPlusMelt                ! intent(in):    rain plus melt (m s-1)
@@ -472,4 +469,29 @@ MODULE data_types
   integer(i4b)             :: err                               ! intent(out):   error code
   character(:),allocatable :: cmessage                          ! intent(out):   error message
  end type out_type_soilLiqFlx
+ ! ** end soilLiqFlx
+
+ ! ** groundwatr
+ type, public :: in_type_groundwatr  ! derived type for intent(in) arguments in groundwatr call
+  integer(i4b)             :: nSnow                             ! intent(in):    number of snow layers
+  integer(i4b)             :: nSoil                             ! intent(in):    number of soil layers
+  integer(i4b)             :: nLayers                           ! intent(in):    total number of layers
+  logical(lgt)             :: firstFluxCall                     ! intent(in):    logical flag to compute index of the lowest saturated layer
+  real(rkind), allocatable :: mLayerdTheta_dPsi(:)              ! intent(in):    derivative in the soil water characteristic w.r.t. matric head in each layer (m-1)
+  real(rkind), allocatable :: mLayerMatricHeadLiqTrial(:)       ! intent(in):    liquid water matric potential (m)
+  real(rkind), allocatable :: mLayerVolFracLiqTrial(:)          ! intent(in):    volumetric fraction of liquid water (-)
+  real(rkind), allocatable :: mLayerVolFracIceTrial(:)          ! intent(in):    volumetric fraction of ice (-)
+ end type in_type_groundwatr
+
+ type, public :: io_type_groundwatr  ! derived type for intent(io) arguments in groundwatr call
+  integer(i4b)             :: ixSaturation                      ! intent(inout): index of lowest saturated layer (NOTE: only computed on the first iteration)
+ end type io_type_groundwatr
+
+ type, public :: out_type_groundwatr ! derived type for intent(out) arguments in groundwatr call
+  real(rkind), allocatable :: mLayerBaseflow(:)                 ! intent(out):   baseflow from each soil layer (m s-1)
+  real(rkind), allocatable :: dBaseflow_dMatric(:,:)            ! intent(out):   derivative in baseflow w.r.t. matric head (s-1)
+  integer(i4b)             :: err                               ! intent(out):   error code
+  character(:),allocatable :: cmessage                          ! intent(out):   error message
+ end type out_type_groundwatr
+ ! ** end groundwatr
 END MODULE data_types

--- a/build/source/dshare/data_types.f90
+++ b/build/source/dshare/data_types.f90
@@ -494,4 +494,32 @@ MODULE data_types
   character(:),allocatable :: cmessage                          ! intent(out):   error message
  end type out_type_groundwatr
  ! ** end groundwatr
+
+ ! ** bigAquifer
+ type, public :: in_type_bigAquifer  ! derived type for intent(in) arguments in bigAquifer call
+  real(rkind)              :: scalarAquiferStorageTrial         ! intent(in):    trial value of aquifer storage (m)
+  real(rkind)              :: scalarCanopyTranspiration         ! intent(in):    canopy transpiration (kg m-2 s-1)
+  real(rkind)              :: scalarSoilDrainage                ! intent(in):    soil drainage (m s-1)
+  real(rkind)              :: dCanopyTrans_dCanWat              ! intent(in):    derivative in canopy transpiration w.r.t. canopy total water content (s-1)
+  real(rkind)              :: dCanopyTrans_dTCanair             ! intent(in):    derivative in canopy transpiration w.r.t. canopy air temperature (kg m-2 s-1 K-1)
+  real(rkind)              :: dCanopyTrans_dTCanopy             ! intent(in):    derivative in canopy transpiration w.r.t. canopy temperature (kg m-2 s-1 K-1)
+  real(rkind)              :: dCanopyTrans_dTGround             ! intent(in):    derivative in canopy transpiration w.r.t. ground temperature (kg m-2 s-1 K-1)
+ end type in_type_bigAquifer
+
+ type, public :: io_type_bigAquifer  ! derived type for intent(inout) arguments in bigAquifer call
+  real(rkind)              :: dAquiferTrans_dTCanair            ! intent(inout): derivatives in the aquifer transpiration flux w.r.t. canopy air temperature
+  real(rkind)              :: dAquiferTrans_dTCanopy            ! intent(inout): derivatives in the aquifer transpiration flux w.r.t. canopy temperature
+  real(rkind)              :: dAquiferTrans_dTGround            ! intent(inout): derivatives in the aquifer transpiration flux w.r.t. ground temperature
+  real(rkind)              :: dAquiferTrans_dCanWat             ! intent(inout): derivatives in the aquifer transpiration flux w.r.t. canopy total water
+ end type io_type_bigAquifer
+
+ type, public :: out_type_bigAquifer  ! derived type for intent(out) arguments in bigAquifer call
+  real(rkind)              :: scalarAquiferTranspire            ! intent(out):   transpiration loss from the aquifer (m s-1)
+  real(rkind)              :: scalarAquiferRecharge             ! intent(out):   recharge to the aquifer (m s-1)
+  real(rkind)              :: scalarAquiferBaseflow             ! intent(out):   total baseflow from the aquifer (m s-1)
+  real(rkind)              :: dBaseflow_dAquifer                ! intent(out):   change in baseflow flux w.r.t. aquifer storage (s-1)
+  integer(i4b)             :: err                               ! intent(out):   error code
+  character(:),allocatable :: cmessage                          ! intent(out):   error message
+ end type out_type_bigAquifer
+ ! ** end bigAquifer
 END MODULE data_types

--- a/build/source/engine/computFlux.f90
+++ b/build/source/engine/computFlux.f90
@@ -42,7 +42,11 @@ USE data_types,only:&
                     out_type_snowLiqFlx,& ! intent(out) arguments for snowLiqFlx call                
                     in_type_soilLiqFlx, & ! intent(in) arguments for soilLiqFlx call
                     io_type_soilLiqFlx, & ! intent(inout) arguments for soilLiqFlx call
-                    out_type_soilLiqFlx   ! intent(in) arguments for soilLiqFlx call
+                    out_type_soilLiqFlx,& ! intent(out) arguments for soilLiqFlx call
+                    in_type_groundwatr, & ! intent(in) arguments for groundwatr call
+                    io_type_groundwatr, & ! intent(inout) arguments for groundwatr call
+                    out_type_groundwatr   ! intent(out) arguments for groundwatr call
+
 
 ! indices that define elements of the data structures
 USE var_lookup,only:iLookDECISIONS  ! named variables for elements of the decision structure
@@ -239,6 +243,9 @@ subroutine computFlux(&
   type(in_type_soilLiqFlx)           :: in_soilLiqFlx               ! data structure for intent(in) soilLiqFlx arguments
   type(io_type_soilLiqFlx)           :: io_soilLiqFlx               ! data structure for intent(inout) soilLiqFlx arguments
   type(out_type_soilLiqFlx)          :: out_soilLiqFlx              ! data structure for intent(out) soilLiqFlx arguments
+  type(in_type_groundwatr)           :: in_groundwatr               ! data structure for intent(in) groundwatr arguments
+  type(io_type_groundwatr)           :: io_groundwatr               ! data structure for intent(inout) groundwatr arguments
+  type(out_type_groundwatr)          :: out_groundwatr              ! data structure for intent(out) groundwatr arguments
   ! --------------------------------------------------------------
   ! initialize error control
   err=0; message='computFlux/'
@@ -506,48 +513,20 @@ subroutine computFlux(&
 
     ! check if computing soil hydrology
     if (nSoilOnlyHyd>0) then
-
       ! set baseflow fluxes to zero if the topmodel baseflow routine is not used
       if (local_ixGroundwater/=qbaseTopmodel) then
-        ! (diagnostic variables in the data structures)
+        ! diagnostic variables in the data structures
         scalarExfiltration     = 0._rkind  ! exfiltration from the soil profile (m s-1)
         mLayerColumnOutflow(:) = 0._rkind  ! column outflow from each soil layer (m3 s-1)
-        ! (variables needed for the numerical solution)
+        ! variables needed for the numerical solution
         mLayerBaseflow(:)      = 0._rkind  ! baseflow from each soil layer (m s-1)
 
         ! topmodel-ish shallow groundwater
       else ! local_ixGroundwater==qbaseTopmodel
-
-        ! check the derivative matrix is sized appropriately
-        if (size(dBaseflow_dMatric,1)/=nSoil .or. size(dBaseflow_dMatric,2)/=nSoil) then
-          message=trim(message)//'expect dBaseflow_dMatric to be nSoil x nSoil'
-          err=20; return
-        end if
-
         ! compute the baseflow flux
-        call groundwatr(&
-                        ! input: model control
-                        nSnow,                                   & ! intent(in):    number of snow layers
-                        nSoil,                                   & ! intent(in):    number of soil layers
-                        nLayers,                                 & ! intent(in):    total number of layers
-                        firstFluxCall,                           & ! intent(in):    logical flag to compute index of the lowest saturated layer
-                        ! input: state and diagnostic variables
-                        mLayerdTheta_dPsi,                       & ! intent(in):    derivative in the soil water characteristic w.r.t. matric head in each layer (m-1)
-                        mLayerMatricHeadLiqTrial,                & ! intent(in):    liquid water matric potential (m)
-                        mLayerVolFracLiqTrial(nSnow+1:nLayers),  & ! intent(in):    volumetric fraction of liquid water (-)
-                        mLayerVolFracIceTrial(nSnow+1:nLayers),  & ! intent(in):    volumetric fraction of ice (-)
-                        ! input: data structures
-                        attr_data,                               & ! intent(in):    model attributes
-                        mpar_data,                               & ! intent(in):    model parameters
-                        prog_data,                               & ! intent(in):    model prognostic variables for a local HRU
-                        diag_data,                               & ! intent(in):    model diagnostic variables for a local HRU
-                        flux_data,                               & ! intent(inout): model fluxes for a local HRU
-                        ! output
-                        ixSaturation,                            & ! intent(inout): index of lowest saturated layer (NOTE: only computed on the first iteration)
-                        mLayerBaseflow,                          & ! intent(out):   baseflow from each soil layer (m s-1)
-                        dBaseflow_dMatric,                       & ! intent(out):   derivative in baseflow w.r.t. matric head (s-1)
-                        err,cmessage)                              ! intent(out):   error control
-        if (err/=0) then; message=trim(message)//trim(cmessage); return; end if
+        call subTools(iLookOP%pre,iLookROUTINE%groundwatr)  ! pre-processing for call to groundwatr
+        call groundwatr(in_groundwatr,attr_data,mpar_data,prog_data,diag_data,flux_data,io_groundwatr,out_groundwatr)
+        call subTools(iLookOP%post,iLookROUTINE%groundwatr) ! post-processing for call to groundwatr
       end if  ! computing baseflow flux
 
       ! compute total baseflow from the soil zone (needed for mass balance checks)
@@ -557,7 +536,6 @@ subroutine computFlux(&
       ! (Note: scalarSoilBaseflow is zero if topmodel is not used)
       ! (Note: scalarSoilBaseflow may need to re-envisioned in topmodel formulation if parts of it flow into neighboring soil rather than exfiltrate)
       scalarTotalRunoff  = scalarSurfaceRunoff + scalarSoilDrainage + scalarSoilBaseflow
-
     end if  ! end if computing soil hydrology
 
 
@@ -1085,9 +1063,32 @@ contains
     end if
    case(iLookROUTINE%groundwatr) ! groundwatr
     if (op==iLookOP%pre) then ! pre-processing
-
+     ! check the derivative matrix is sized appropriately
+     if (size(dBaseflow_dMatric,1)/=nSoil .or. size(dBaseflow_dMatric,2)/=nSoil) then
+       message=trim(message)//'expect dBaseflow_dMatric to be nSoil x nSoil'
+       err=20; return
+     end if
+     ! intent(in) arguments
+     in_groundwatr % nSnow                    = nSnow                                  ! intent(in):    number of snow layers
+     in_groundwatr % nSoil                    = nSoil                                  ! intent(in):    number of soil layers
+     in_groundwatr % nLayers                  = nLayers                                ! intent(in):    total number of layers
+     in_groundwatr % firstFluxCall            = firstFluxCall                          ! intent(in):    logical flag to compute index of the lowest saturated layer
+     in_groundwatr % mLayerdTheta_dPsi        = mLayerdTheta_dPsi                      ! intent(in):    derivative in the soil water characteristic w.r.t. matric head in each layer (m-1)
+     in_groundwatr % mLayerMatricHeadLiqTrial = mLayerMatricHeadLiqTrial               ! intent(in):    liquid water matric potential (m)
+     in_groundwatr % mLayerVolFracLiqTrial    = mLayerVolFracLiqTrial(nSnow+1:nLayers) ! intent(in):    volumetric fraction of liquid water (-)
+     in_groundwatr % mLayerVolFracIceTrial    = mLayerVolFracIceTrial(nSnow+1:nLayers) ! intent(in):    volumetric fraction of ice (-)
+     ! intent(inout) arguments
+     io_groundwatr % ixSaturation = ixSaturation ! intent(inout): index of lowest saturated layer (NOTE: only computed on the first iteration)
     else ! post-processing
-
+     ! intent(inout) arguments
+     ixSaturation = io_groundwatr % ixSaturation ! intent(inout): index of lowest saturated layer (NOTE: only computed on the first iteration)
+     ! intent(out) arguments
+     mLayerBaseflow    = out_groundwatr % mLayerBaseflow                               ! intent(out):   baseflow from each soil layer (m s-1)
+     dBaseflow_dMatric = out_groundwatr % dBaseflow_dMatric                            ! intent(out):   derivative in baseflow w.r.t. matric head (s-1)
+     err               = out_groundwatr % err                                          ! intent(out):   error code
+     cmessage          = out_groundwatr % cmessage                                     ! intent(out):   error message
+     ! error control
+     if (err/=0) then; message=trim(message)//trim(cmessage); return; end if
     end if
    case(iLookROUTINE%bigAquifer) ! bigAquifer
     if (op==iLookOP%pre) then ! pre-processing

--- a/build/source/engine/groundwatr.f90
+++ b/build/source/engine/groundwatr.f90
@@ -81,18 +81,18 @@ contains
 !
 ! ************************************************************************************************
 subroutine groundwatr(&
-                    ! input: model control, state variables, and diagnostic variables
-                    in_groundwatr,                          & ! intent(in): model control, state variables, and diagnostic variables
-                    ! input/output: data structures
-                    attr_data,                              & ! intent(in):    spatial attributes
-                    mpar_data,                              & ! intent(in):    model parameters
-                    prog_data,                              & ! intent(in):    model prognostic variables for a local HRU
-                    diag_data,                              & ! intent(in):    model diagnostic variables for a local HRU
-                    flux_data,                              & ! intent(inout): model fluxes for a local HRU
-                    ! input-output: baseflow
-                    io_groundwatr,                          & ! intent(inout): index of lowest saturated layer (NOTE: only computed on the first iteration)
-                    ! output: baseflow and error control
-                    out_groundwatr)                           ! intent(out):   baseflow and error control
+                      ! input: model control, state variables, and diagnostic variables
+                      in_groundwatr,                          & ! intent(in): model control, state variables, and diagnostic variables
+                      ! input/output: data structures
+                      attr_data,                              & ! intent(in):    spatial attributes
+                      mpar_data,                              & ! intent(in):    model parameters
+                      prog_data,                              & ! intent(in):    model prognostic variables for a local HRU
+                      diag_data,                              & ! intent(in):    model diagnostic variables for a local HRU
+                      flux_data,                              & ! intent(inout): model fluxes for a local HRU
+                      ! input-output: baseflow
+                      io_groundwatr,                          & ! intent(inout): index of lowest saturated layer (NOTE: only computed on the first iteration)
+                      ! output: baseflow and error control
+                      out_groundwatr)                           ! intent(out):   baseflow and error control
   ! ---------------------------------------------------------------------------------------
   ! utility modules
   USE soil_utils_module,only:volFracLiq                       ! compute volumetric fraction of liquid water as a function of matric head


### PR DESCRIPTION
Hi @ashleymedin - This PR is for updates shortening the call syntax length for the groundwatr and bigAquifer subroutines. This is done using new derived types to handle most of the subroutine arguments (except the larger data structures to avoid memory use increases). This update doe not affect test suite output or resource use (laugh + WRR tests). This PR is part of the "length of a t-shirt" series.

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] closes #xxx (identify the issue associated with this PR)
- [x] tests passed
- [ ] new tests added
- [ ] science test figures
- [ ] checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] ReleaseNotes entry
