### PR TITLE
Simplify call to varSubstep in opSplitting using object-oriented methods

### DIFF
--- a/build/source/dshare/data_types.f90
+++ b/build/source/dshare/data_types.f90
@@ -308,7 +308,7 @@ MODULE data_types
  ! ***********************************************************************************************************
  ! Note: class procedures are located in the contains block of this (data_types) module
  ! ** vegNrgFlux
- type, public :: in_type_vegNrgFlux ! derived type for intent(in) arguments in vegNrgFlux call
+ type, public :: in_type_vegNrgFlux ! class for intent(in) arguments in vegNrgFlux call
    logical(lgt)             :: firstSubStep                      ! intent(in): flag to indicate if we are processing the first sub-step
    logical(lgt)             :: firstFluxCall                     ! intent(in): flag to indicate if we are processing the first flux call
    logical(lgt)             :: computeVegFlux                    ! intent(in): flag to indicate if we need to compute fluxes over vegetation
@@ -324,7 +324,7 @@ MODULE data_types
    procedure :: initialize => initialize_in_vegNrgFlux
  end type in_type_vegNrgFlux
 
- type, public :: out_type_vegNrgFlux ! derived type for intent(out) arguments in vegNrgFlux call
+ type, public :: out_type_vegNrgFlux ! class for intent(out) arguments in vegNrgFlux call
    real(rkind)              :: scalarCanopyTranspiration               ! intent(out): canopy transpiration (kg m-2 s-1)
    real(rkind)              :: scalarCanopyEvaporation                 ! intent(out): canopy evaporation/condensation (kg m-2 s-1)
    real(rkind)              :: scalarGroundEvaporation                 ! intent(out): ground evaporation/condensation -- below canopy or non-vegetated (kg m-2 s-1)
@@ -362,7 +362,7 @@ MODULE data_types
  ! ** end vegNrgFlux
 
  ! ** ssdNrgFlux
- type, public :: in_type_ssdNrgFlux ! derived type for intent(in) arguments in ssdNrgFlux call
+ type, public :: in_type_ssdNrgFlux ! class for intent(in) arguments in ssdNrgFlux call
    logical(lgt)             :: scalarSolution                    ! intent(in): flag to denote if implementing the scalar solution
    real(rkind)              :: scalarGroundNetNrgFlux            ! intent(in): net energy flux for the ground surface (W m-2)
    real(rkind), allocatable :: iLayerLiqFluxSnow(:)              ! intent(in): liquid flux at the interface of each snow layer (m s-1)
@@ -376,14 +376,14 @@ MODULE data_types
    procedure :: initialize => initialize_in_ssdNrgFlux
  end type in_type_ssdNrgFlux
 
- type, public :: io_type_ssdNrgFlux ! derived type for intent(inout) arguments in ssdNrgFlux call
+ type, public :: io_type_ssdNrgFlux ! class for intent(inout) arguments in ssdNrgFlux call
    real(rkind)              :: dGroundNetFlux_dGroundTemp        ! intent(inout): derivative in net ground flux w.r.t. ground temperature (W m-2 K-1)
   contains
    procedure :: initialize => initialize_io_ssdNrgFlux
    procedure :: finalize   => finalize_io_ssdNrgFlux
  end type io_type_ssdNrgFlux
 
- type, public :: out_type_ssdNrgFlux ! derived type for intent(inout) arguments in ssdNrgFlux call
+ type, public :: out_type_ssdNrgFlux ! class for intent(inout) arguments in ssdNrgFlux call
    real(rkind), allocatable :: iLayerNrgFlux(:)                  ! intent(out): energy flux at the layer interfaces (W m-2)
    real(rkind), allocatable :: dNrgFlux_dTempAbove(:)            ! intent(out): derivatives in the flux w.r.t. temperature in the layer above (J m-2 s-1 K-1)
    real(rkind), allocatable :: dNrgFlux_dTempBelow(:)            ! intent(out): derivatives in the flux w.r.t. temperature in the layer below (J m-2 s-1 K-1)
@@ -437,7 +437,7 @@ MODULE data_types
    procedure :: finalize   => finalize_io_snowLiqFlx
  end type io_type_snowLiqFlx
 
- type, public :: out_type_snowLiqFlx ! derived type for intent(out) arguments in snowLiqFlx call
+ type, public :: out_type_snowLiqFlx ! class for intent(out) arguments in snowLiqFlx call
    integer(i4b)             :: err                               ! intent(out):   error code
    character(:),allocatable :: cmessage                          ! intent(out):   error message
   contains
@@ -446,7 +446,7 @@ MODULE data_types
  ! ** end snowLiqFlx
 
  ! ** soilLiqFlx
- type, public :: in_type_soilLiqFlx ! derived type for intent(in) arguments in soilLiqFlx call
+ type, public :: in_type_soilLiqFlx ! class for intent(in) arguments in soilLiqFlx call
    integer(i4b)             :: nSoil                             ! intent(in):    number of soil layers
    logical(lgt)             :: firstSplitOper                    ! intent(in):    flag indicating first flux call in a splitting operation
    logical(lgt)             :: scalarSolution                    ! intent(in):    flag to indicate the scalar solution
@@ -472,7 +472,7 @@ MODULE data_types
    procedure :: initialize => initialize_in_soilLiqFlx
  end type in_type_soilLiqFlx
 
- type, public :: io_type_soilLiqFlx ! derived type for intent(inout) arguments in soilLiqFlx call
+ type, public :: io_type_soilLiqFlx ! class for intent(inout) arguments in soilLiqFlx call
    real(rkind)              :: scalarMaxInfilRate                ! intent(inout): maximum infiltration rate (m s-1)
    real(rkind)              :: scalarInfilArea                   ! intent(inout): fraction of unfrozen area where water can infiltrate (-)
    real(rkind)              :: scalarFrozenArea                  ! intent(inout): fraction of area that is considered impermeable due to soil ice (-)
@@ -499,7 +499,7 @@ MODULE data_types
    procedure :: finalize   => finalize_io_soilLiqFlx
  end type io_type_soilLiqFlx
 
- type, public :: out_type_soilLiqFlx ! derived type for intent(out) arguments in soilLiqFlx call
+ type, public :: out_type_soilLiqFlx ! class for intent(out) arguments in soilLiqFlx call
    integer(i4b)             :: err                               ! intent(out):   error code
    character(:),allocatable :: cmessage                          ! intent(out):   error message
   contains
@@ -508,7 +508,7 @@ MODULE data_types
  ! ** end soilLiqFlx
 
  ! ** groundwatr
- type, public :: in_type_groundwatr  ! derived type for intent(in) arguments in groundwatr call
+ type, public :: in_type_groundwatr  ! class for intent(in) arguments in groundwatr call
    integer(i4b)             :: nSnow                             ! intent(in):    number of snow layers
    integer(i4b)             :: nSoil                             ! intent(in):    number of soil layers
    integer(i4b)             :: nLayers                           ! intent(in):    total number of layers
@@ -521,14 +521,14 @@ MODULE data_types
    procedure :: initialize => initialize_in_groundwatr
  end type in_type_groundwatr
 
- type, public :: io_type_groundwatr  ! derived type for intent(io) arguments in groundwatr call
+ type, public :: io_type_groundwatr  ! class for intent(io) arguments in groundwatr call
    integer(i4b)             :: ixSaturation                      ! intent(inout): index of lowest saturated layer (NOTE: only computed on the first iteration)
   contains
    procedure :: initialize => initialize_io_groundwatr
    procedure :: finalize   => finalize_io_groundwatr 
  end type io_type_groundwatr
 
- type, public :: out_type_groundwatr ! derived type for intent(out) arguments in groundwatr call
+ type, public :: out_type_groundwatr ! class for intent(out) arguments in groundwatr call
    real(rkind), allocatable :: mLayerBaseflow(:)                 ! intent(out):   baseflow from each soil layer (m s-1)
    real(rkind), allocatable :: dBaseflow_dMatric(:,:)            ! intent(out):   derivative in baseflow w.r.t. matric head (s-1)
    integer(i4b)             :: err                               ! intent(out):   error code
@@ -539,7 +539,7 @@ MODULE data_types
  ! ** end groundwatr
 
  ! ** bigAquifer
- type, public :: in_type_bigAquifer  ! derived type for intent(in) arguments in bigAquifer call
+ type, public :: in_type_bigAquifer  ! class for intent(in) arguments in bigAquifer call
    real(rkind)              :: scalarAquiferStorageTrial         ! intent(in):    trial value of aquifer storage (m)
    real(rkind)              :: scalarCanopyTranspiration         ! intent(in):    canopy transpiration (kg m-2 s-1)
    real(rkind)              :: scalarSoilDrainage                ! intent(in):    soil drainage (m s-1)
@@ -551,7 +551,7 @@ MODULE data_types
    procedure :: initialize => initialize_in_bigAquifer
  end type in_type_bigAquifer
 
- type, public :: io_type_bigAquifer  ! derived type for intent(inout) arguments in bigAquifer call
+ type, public :: io_type_bigAquifer  ! class for intent(inout) arguments in bigAquifer call
    real(rkind)              :: dAquiferTrans_dTCanair            ! intent(inout): derivatives in the aquifer transpiration flux w.r.t. canopy air temperature
    real(rkind)              :: dAquiferTrans_dTCanopy            ! intent(inout): derivatives in the aquifer transpiration flux w.r.t. canopy temperature
    real(rkind)              :: dAquiferTrans_dTGround            ! intent(inout): derivatives in the aquifer transpiration flux w.r.t. ground temperature
@@ -561,7 +561,7 @@ MODULE data_types
    procedure :: finalize   => finalize_io_bigAquifer
  end type io_type_bigAquifer
 
- type, public :: out_type_bigAquifer  ! derived type for intent(out) arguments in bigAquifer call
+ type, public :: out_type_bigAquifer  ! class for intent(out) arguments in bigAquifer call
    real(rkind)              :: scalarAquiferTranspire            ! intent(out):   transpiration loss from the aquifer (m s-1)
    real(rkind)              :: scalarAquiferRecharge             ! intent(out):   recharge to the aquifer (m s-1)
    real(rkind)              :: scalarAquiferBaseflow             ! intent(out):   total baseflow from the aquifer (m s-1)
@@ -574,7 +574,7 @@ MODULE data_types
  ! ** end bigAquifer
 
  ! ** varSubstep
- type, public :: in_type_varSubstep  ! derived type for intent(in) arguments in varSubstep call
+ type, public :: in_type_varSubstep  ! class for intent(in) arguments in varSubstep call
    real(rkind)              :: dt                          ! intent(in): time step (s)
    real(rkind)              :: dtInit                      ! intent(in): initial time step (seconds)
    real(rkind)              :: dt_min                      ! intent(in): minimum time step (seconds)
@@ -590,15 +590,16 @@ MODULE data_types
    procedure :: initialize => initialize_in_varSubstep
  end type in_type_varSubstep
 
- type, public :: io_type_varSubstep  ! derived type for intent(inout) arguments in varSubstep call
-   logical(lgt)             :: firstFluxCall               ! intent(inout) : flag to indicate if we are processing the first flux call
-   integer(i4b)             :: fluxCount                   ! intent(inout) : number of times fluxes are updated (should equal nsubstep)
-   integer(i4b)             :: ixSaturation                ! intent(inout) : index of the lowest saturated layer (NOTE: only computed on the first iteration)
+ type, public :: io_type_varSubstep  ! class for intent(inout) arguments in varSubstep call
+   logical(lgt)             :: firstFluxCall               ! intent(inout): flag to indicate if we are processing the first flux call
+   type(var_ilength)        :: fluxCount                   ! intent(inout): number of times fluxes are updated (should equal nsubstep)
+   integer(i4b)             :: ixSaturation                ! intent(inout): index of the lowest saturated layer (NOTE: only computed on the first iteration)
   contains
-
+   procedure :: initialize => initialize_io_varSubstep
+   procedure :: finalize   => finalize_io_varSubstep
  end type io_type_varSubstep
 
- type, public :: out_type_varSubstep  ! derived type for intent(out) arguments in varSubstep call
+ type, public :: out_type_varSubstep  ! class for intent(out) arguments in varSubstep call
    real(rkind)              :: dtMultiplier                ! intent(out): substep multiplier (-)
    integer(i4b)             :: nSubsteps                   ! intent(out): number of substeps taken for a given split
    logical(lgt)             :: failedMinimumStep           ! intent(out): flag for failed substeps
@@ -607,7 +608,7 @@ MODULE data_types
    integer(i4b)             :: err                         ! intent(out): error code
    character(:),allocatable :: cmessage                    ! intent(out): error message
   contains
-
+   procedure :: finalize   => finalize_out_varSubstep
  end type out_type_varSubstep
  ! ** end varSubstep
 
@@ -1277,5 +1278,50 @@ contains
   in_varSubstep % iStateSplit    = iStateSplit            ! intent(in): index of the layer in the splitting operation
   in_varSubstep % fluxMask       = fluxMask               ! intent(in): mask for the fluxes used in this given state subset
  end subroutine initialize_in_varSubstep
+
+ subroutine initialize_io_varSubstep(io_varSubstep,firstFluxCall,fluxCount,ixSaturation)
+  class(io_type_varSubstep),intent(out) :: io_varSubstep  ! class object for intent(in) varSubstep arguments
+  logical(lgt),intent(in)               :: firstFluxCall  ! flag to indicate if we are processing the first flux call
+  type(var_ilength),intent(in)          :: fluxCount      ! number of times fluxes are updated (should equal nsubstep)
+  integer(i4b),intent(in)               :: ixSaturation   ! index of the lowest saturated layer (NOTE: only computed on the first iteration)
+
+  ! intent(inout) arguments
+  io_varSubstep % firstFluxCall = firstFluxCall           ! intent(inout): flag to indicate if we are processing the first flux call
+  io_varSubstep % fluxCount     = fluxCount               ! intent(inout): number of times fluxes are updated (should equal nsubstep)
+  io_varSubstep % ixSaturation  = ixSaturation            ! intent(inout): index of the lowest saturated layer (NOTE: only computed on the first iteration)
+ end subroutine initialize_io_varSubstep
+
+ subroutine finalize_io_varSubstep(io_varSubstep,firstFluxCall,fluxCount,ixSaturation)
+  class(io_type_varSubstep),intent(in)  :: io_varSubstep  ! class object for intent(in) varSubstep arguments
+  logical(lgt),intent(out)              :: firstFluxCall  ! flag to indicate if we are processing the first flux call
+  type(var_ilength),intent(out)         :: fluxCount      ! number of times fluxes are updated (should equal nsubstep)
+  integer(i4b),intent(out)              :: ixSaturation   ! index of the lowest saturated layer (NOTE: only computed on the first iteration)
+
+  ! intent(inout) arguments
+  firstFluxCall = io_varSubstep % firstFluxCall           ! intent(inout): flag to indicate if we are processing the first flux call
+  fluxCount     = io_varSubstep % fluxCount               ! intent(inout): number of times fluxes are updated (should equal nsubstep)
+  ixSaturation  = io_varSubstep % ixSaturation            ! intent(inout): index of the lowest saturated layer (NOTE: only computed on the first iteration)
+ end subroutine finalize_io_varSubstep
+
+ subroutine finalize_out_varSubstep(out_varSubstep,dtMultiplier,nSubsteps,failedMinimumStep,reduceCoupledStep,tooMuchMelt,err,cmessage)
+  class(out_type_varSubstep),intent(in) :: out_varSubstep    ! class object for intent(out) varSubstep arguments
+  real(rkind),intent(out)               :: dtMultiplier      ! substep multiplier (-)
+  integer(i4b),intent(out)              :: nSubsteps         ! number of substeps taken for a given split
+  logical(lgt),intent(out)              :: failedMinimumStep ! flag for failed substeps
+  logical(lgt),intent(out)              :: reduceCoupledStep ! flag to reduce the length of the coupled step
+  logical(lgt),intent(out)              :: tooMuchMelt       ! flag to denote that ice is insufficient to support melt
+  integer(i4b),intent(out)              :: err               ! error code
+  character(*),intent(out)              :: cmessage          ! error message                                          
+
+  ! intent(out) arguments
+  dtMultiplier      = out_varSubstep % dtMultiplier       ! intent(out): substep multiplier (-)
+  nSubsteps         = out_varSubstep % nSubsteps          ! intent(out): number of substeps taken for a given split
+  failedMinimumStep = out_varSubstep % failedMinimumStep  ! intent(out): flag for failed substeps
+  reduceCoupledStep = out_varSubstep % reduceCoupledStep  ! intent(out): flag to reduce the length of the coupled step
+  tooMuchMelt       = out_varSubstep % tooMuchMelt        ! intent(out): flag to denote that ice is insufficient to support melt
+  err               = out_varSubstep % err                ! intent(out): error code
+  cmessage          = out_varSubstep % cmessage           ! intent(out): error message                                          
+ end subroutine finalize_out_varSubstep
  ! **** end varSubstep ****
+
 END MODULE data_types

--- a/build/source/engine/varSubstep.f90
+++ b/build/source/engine/varSubstep.f90
@@ -42,14 +42,16 @@ USE globalData,only:flux_meta       ! metadata on the model fluxes
 
 ! derived types to define the data structures
 USE data_types,only:&
-                    var_i,           & ! data vector (i4b)
-                    var_d,           & ! data vector (rkind)
-                    var_flagVec,     & ! data vector with variable length dimension (i4b)
-                    var_ilength,     & ! data vector with variable length dimension (i4b)
-                    var_dlength,     & ! data vector with variable length dimension (rkind)
-                    zLookup,         & ! lookup tables
-                    model_options,   & ! defines the model decisions
-                    in_type_varSubstep ! class for intent(in) arguments
+                    var_i,              & ! data vector (i4b)
+                    var_d,              & ! data vector (rkind)
+                    var_flagVec,        & ! data vector with variable length dimension (i4b)
+                    var_ilength,        & ! data vector with variable length dimension (i4b)
+                    var_dlength,        & ! data vector with variable length dimension (rkind)
+                    zLookup,            & ! lookup tables
+                    model_options,      & ! defines the model decisions
+                    in_type_varSubstep, & ! class for intent(in) arguments
+                    io_type_varSubstep, & ! class for intent(inout) arguments
+                    out_type_varSubstep   ! class for intent(out) arguments
 
 ! provide access to indices that define elements of the data structures
 USE var_lookup,only:iLookFLUX       ! named variables for structure elements
@@ -94,8 +96,7 @@ contains
 subroutine varSubstep(&
                       ! input: model control
                       in_varSubstep,     & ! intent(in)    : model control
-                      firstFluxCall,     & ! intent(inout) : flag to indicate if we are processing the first flux call
-                      fluxCount,         & ! intent(inout) : number of times that fluxes are updated (should equal nSubsteps)
+                      io_varSubstep,     & ! intent(inout) : model control
                       ! input/output: data structures
                       model_decisions,   & ! intent(in)    : model decisions
                       lookup_data,       & ! intent(in)    : lookup tables
@@ -111,13 +112,7 @@ subroutine varSubstep(&
                       deriv_data,        & ! intent(inout) : derivatives in model fluxes w.r.t. relevant state variables
                       bvar_data,         & ! intent(in)    : model variables for the local basin
                       ! output: model control
-                      ixSaturation,      & ! intent(inout) : index of the lowest saturated layer (NOTE: only computed on the first iteration)
-                      dtMultiplier,      & ! intent(out)   : substep multiplier (-)
-                      nSubsteps,         & ! intent(out)   : number of substeps taken for a given split
-                      failedMinimumStep, & ! intent(out)   : flag to denote success of substepping for a given split
-                      reduceCoupledStep, & ! intent(out)   : flag to denote need to reduce the length of the coupled step
-                      tooMuchMelt,       & ! intent(out)   : flag to denote that ice is insufficient to support melt
-                      err,message)         ! intent(out)   : error code and error message
+                      out_varSubstep)      ! intent(out)   : model control
   ! ---------------------------------------------------------------------------------------
   ! structure allocations
   USE allocspace_module,only:allocLocal                ! allocate local data structures
@@ -131,33 +126,25 @@ subroutine varSubstep(&
   ! ---------------------------------------------------------------------------------------
   ! * dummy variables
   ! ---------------------------------------------------------------------------------------
-  type(in_type_varSubstep),intent(in) :: in_varSubstep                ! model control
   ! input: model control
-  logical(lgt),intent(inout)         :: firstFluxCall                 ! flag to define the first flux call
-  type(var_ilength),intent(inout)    :: fluxCount                     ! number of times that the flux is updated (should equal nSubsteps)
+  type(in_type_varSubstep),intent(in)    :: in_varSubstep             ! model control
+  type(io_type_varSubstep),intent(inout) :: io_varSubstep             ! model control
   ! input/output: data structures
-  type(model_options),intent(in)     :: model_decisions(:)            ! model decisions
-  type(zLookup),intent(in)           :: lookup_data                   ! lookup tables
-  type(var_i),intent(in)             :: type_data                     ! type of vegetation and soil
-  type(var_d),intent(in)             :: attr_data                     ! spatial attributes
-  type(var_d),intent(in)             :: forc_data                     ! model forcing data
-  type(var_dlength),intent(in)       :: mpar_data                     ! model parameters
-  type(var_ilength),intent(inout)    :: indx_data                     ! indices for a local HRU
-  type(var_dlength),intent(inout)    :: prog_data                     ! prognostic variables for a local HRU
-  type(var_dlength),intent(inout)    :: diag_data                     ! diagnostic variables for a local HRU
-  type(var_dlength),intent(inout)    :: flux_data                     ! model fluxes for a local HRU
-  type(var_dlength),intent(inout)    :: flux_mean                     ! mean model fluxes for a local HRU
-  type(var_dlength),intent(inout)    :: deriv_data                    ! derivatives in model fluxes w.r.t. relevant state variables
-  type(var_dlength),intent(in)       :: bvar_data                     ! model variables for the local basin
+  type(model_options),intent(in)         :: model_decisions(:)        ! model decisions
+  type(zLookup),intent(in)               :: lookup_data               ! lookup tables
+  type(var_i),intent(in)                 :: type_data                 ! type of vegetation and soil
+  type(var_d),intent(in)                 :: attr_data                 ! spatial attributes
+  type(var_d),intent(in)                 :: forc_data                 ! model forcing data
+  type(var_dlength),intent(in)           :: mpar_data                 ! model parameters
+  type(var_ilength),intent(inout)        :: indx_data                 ! indices for a local HRU
+  type(var_dlength),intent(inout)        :: prog_data                 ! prognostic variables for a local HRU
+  type(var_dlength),intent(inout)        :: diag_data                 ! diagnostic variables for a local HRU
+  type(var_dlength),intent(inout)        :: flux_data                 ! model fluxes for a local HRU
+  type(var_dlength),intent(inout)        :: flux_mean                 ! mean model fluxes for a local HRU
+  type(var_dlength),intent(inout)        :: deriv_data                ! derivatives in model fluxes w.r.t. relevant state variables
+  type(var_dlength),intent(in)           :: bvar_data                 ! model variables for the local basin
   ! output: model control
-  integer(i4b),intent(inout)         :: ixSaturation                  ! index of the lowest saturated layer (NOTE: only computed on the first iteration)
-  real(rkind),intent(out)            :: dtMultiplier                  ! substep multiplier (-)
-  integer(i4b),intent(out)           :: nSubsteps                     ! number of substeps taken for a given split
-  logical(lgt),intent(out)           :: failedMinimumStep             ! flag to denote success of substepping for a given split
-  logical(lgt),intent(out)           :: reduceCoupledStep             ! flag to denote need to reduce the length of the coupled step
-  logical(lgt),intent(out)           :: tooMuchMelt                   ! flag to denote that ice is insufficient to support melt
-  integer(i4b),intent(out)           :: err                           ! error code
-  character(*),intent(out)           :: message                       ! error message
+  type(out_type_varSubstep),intent(out)  :: out_varSubstep            ! model control
   ! ---------------------------------------------------------------------------------------
   ! * general local variables
   ! ---------------------------------------------------------------------------------------
@@ -215,6 +202,9 @@ subroutine varSubstep(&
     scalarSolution => in_varSubstep % scalarSolution, & ! intent(in): flag to denote implementing the scalar solution
     iStateSplit    => in_varSubstep % iStateSplit,    & ! intent(in): index of the state in the splitting operation
     fluxMask       => in_varSubstep % fluxMask,       & ! intent(in): flags to denote if the flux is calculated in the given state subset
+    firstFluxCall  => io_varSubstep % firstFluxCall,  & ! intent(inout): flag to define the first flux call
+    fluxCount      => io_varSubstep % fluxCount,      & ! intent(inout): number of times that the flux is updated (should equal nSubsteps)
+    ixSaturation   => io_varSubstep % ixSaturation,   & ! intent(inout): index of the lowest saturated layer (NOTE: only computed on the first iteration)
     ! model decisions
     ixNumericalMethod       => model_decisions(iLookDECISIONS%num_method)%iDecision   ,& ! intent(in):    [i4b]    choice of numerical solver
     ! number of layers
@@ -239,7 +229,15 @@ subroutine varSubstep(&
     mLayerVolFracLiq        => prog_data%var(iLookPROG%mLayerVolFracLiq)%dat          ,& ! intent(inout): [dp(:)]  volumetric fraction of liquid water (-)
     mLayerVolFracWat        => prog_data%var(iLookPROG%mLayerVolFracWat)%dat          ,& ! intent(inout): [dp(:)]  volumetric fraction of total water (-)
     mLayerMatricHead        => prog_data%var(iLookPROG%mLayerMatricHead)%dat          ,& ! intent(inout): [dp(:)]  matric head (m)
-    mLayerMatricHeadLiq     => diag_data%var(iLookDIAG%mLayerMatricHeadLiq)%dat        & ! intent(inout): [dp(:)]  matric potential of liquid water (m)
+    mLayerMatricHeadLiq     => diag_data%var(iLookDIAG%mLayerMatricHeadLiq)%dat       ,& ! intent(inout): [dp(:)]  matric potential of liquid water (m)
+    ! model control
+    dtMultiplier      => out_varSubstep % dtMultiplier             ,& ! intent(out): substep multiplier (-)
+    nSubsteps         => out_varSubstep % nSubsteps                ,& ! intent(out): number of substeps taken for a given split
+    failedMinimumStep => out_varSubstep % failedMinimumStep        ,& ! intent(out): flag to denote success of substepping for a given split
+    reduceCoupledStep => out_varSubstep % reduceCoupledStep        ,& ! intent(out): flag to denote need to reduce the length of the coupled step
+    tooMuchMelt       => out_varSubstep % tooMuchMelt              ,& ! intent(out): flag to denote that ice is insufficient to support melt
+    err               => out_varSubstep % err                      ,& ! intent(out): error code
+    message           => out_varSubstep % cmessage                  & ! intent(out): error message
     )  ! end association with variables in the data structures
     ! *********************************************************************************************************************************************************
    
@@ -544,14 +542,13 @@ subroutine varSubstep(&
     end do
     deallocate(sumLayerCompress)
 
+    ! update error codes
+    if (failedMinimumStep) then
+      err=-20 ! negative = recoverable error
+      message=trim(message)//'failed minimum step'
+    end if
   ! end associate statements
   end associate globalVars
-
-  ! update error codes
-  if(failedMinimumStep)then
-    err=-20 ! negative = recoverable error
-    message=trim(message)//'failed minimum step'
-  endif
 end subroutine varSubstep
 
 


### PR DESCRIPTION
Hi @ashleymedin - This PR applies object-oriented methods to simplify argument passing to varSubstep from opSplittin. Specifically, classes for each intent attribute for varSubstep's arguments were created in data_types.f90. Type-bound procedures in the varSubstep classes handle the data transfer to/from class objects declared in varSubstep and opSplittin. Initialize and finalize routines for varSubstep were also added to the contains block of opSplittin.

The strategy is similar to that used for the flux calls in computFlux in previous PRs. Modularization within opSplittin is enhanced and the number of arguments for varSubstep has been reduced.

This PR is organizational with some additional cosmetic updates and does not alter the output or resource use for the test suite. Also, Kyle's recent PR #25 was included for the tests.  

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] closes #xxx (identify the issue associated with this PR)
- [x] tests passed
- [ ] new tests added
- [ ] science test figures
- [ ] checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] ReleaseNotes entry
