### PR TITLE
Applied object-oriented methods to simplify call to stateFilter in opSplittin

### DIFF
--- a/build/source/dshare/data_types.f90
+++ b/build/source/dshare/data_types.f90
@@ -573,6 +573,27 @@ MODULE data_types
  end type out_type_bigAquifer
  ! ** end bigAquifer
 
+ ! ** stateFilter
+ type, public :: in_type_stateFilter  ! class for intent(in) arguments in stateFilter call
+   integer(i4b)             :: ixCoupling                  ! intent(in): index of coupling method (1,2)
+   integer(i4b)             :: ixSolution                  ! intent(in): index of solution method (1,2)
+   integer(i4b)             :: ixStateThenDomain           ! intent(in): switch between full domain and sub domains
+   integer(i4b)             :: iStateTypeSplit             ! intent(in): index of the state type split
+   integer(i4b)             :: iDomainSplit                ! intent(in): index of the domain split
+   integer(i4b)             :: iStateSplit                 ! intent(in): index of the layer split
+  contains
+   procedure :: initialize => initialize_in_stateFilter
+ end type in_type_stateFilter
+
+ type, public :: out_type_stateFilter ! class for intent(out) arguments in stateFilter call
+   integer(i4b)             :: nSubset                     ! intent(out): number of selected state variables for a given split
+   integer(i4b)             :: err                         ! intent(out): error code
+   character(:),allocatable :: cmessage                    ! intent(out): error message
+  contains
+   procedure :: finalize   => finalize_out_stateFilter
+ end type out_type_stateFilter
+ ! ** end stateFilter
+
  ! ** varSubstep
  type, public :: in_type_varSubstep  ! class for intent(in) arguments in varSubstep call
    real(rkind)              :: dt                          ! intent(in): time step (s)
@@ -1247,6 +1268,34 @@ contains
   end associate
  end subroutine finalize_out_bigAquifer
  ! **** end bigAquifer ****
+
+ ! **** stateFilter ****
+ subroutine initialize_in_stateFilter(in_stateFilter,ixCoupling,ixSolution,ixStateThenDomain,iStateTypeSplit,iDomainSplit,iStateSplit)
+  class(in_type_stateFilter),intent(out) :: in_stateFilter    ! class object for intent(in) stateFilter arguments
+  integer(i4b),intent(in)                :: ixCoupling        ! intent(in): index of coupling method (1,2)
+  integer(i4b),intent(in)                :: ixSolution        ! intent(in): index of solution method (1,2)
+  integer(i4b),intent(in)                :: ixStateThenDomain ! intent(in): switch between full domain and sub domains
+  integer(i4b),intent(in)                :: iStateTypeSplit   ! intent(in): index of the state type split
+  integer(i4b),intent(in)                :: iDomainSplit      ! intent(in): index of the domain split
+  integer(i4b),intent(in)                :: iStateSplit       ! intent(in): index of the layer split
+  in_stateFilter % ixCoupling        = ixCoupling             ! intent(in): index of coupling method (1,2)
+  in_stateFilter % ixSolution        = ixSolution             ! intent(in): index of solution method (1,2)
+  in_stateFilter % ixStateThenDomain = ixStateThenDomain      ! intent(in): switch between full domain and sub domains
+  in_stateFilter % iStateTypeSplit   = iStateTypeSplit        ! intent(in): index of the state type split
+  in_stateFilter % iDomainSplit      = iDomainSplit           ! intent(in): index of the domain split
+  in_stateFilter % iStateSplit       = iStateSplit            ! intent(in): index of the layer split
+ end subroutine initialize_in_stateFilter
+
+ subroutine finalize_out_stateFilter(out_stateFilter,nSubset,err,cmessage)
+  class(out_type_stateFilter),intent(in) :: out_stateFilter   ! class object for intent(in) stateFilter arguments
+  integer(i4b),intent(out)               :: nSubset           ! intent(out): number of selected state variables for a given split
+  integer(i4b),intent(out)               :: err               ! intent(out): error code
+  character(*),intent(out)               :: cmessage          ! intent(out): error message
+  nSubset  = out_stateFilter % nSubset                        ! intent(out): number of selected state variables for a given split 
+  err      = out_stateFilter % err                            ! intent(out): error code
+  cmessage = out_stateFilter % cmessage                       ! intent(out): error message
+ end subroutine finalize_out_stateFilter
+ ! **** end stateFilter ****
 
  ! **** varSubstep ****
  subroutine initialize_in_varSubstep(in_varSubstep,dt,dtInit,dt_min,whole_step,nSubset,&


### PR DESCRIPTION
Hi @ashleymedin - this PR adds object-oriented methods for the call to stateFilter in opSplittin. New classes designed to handle the passing of subroutine argument data were added to data_types.f90. Initialize and finalize steps, comprised of class procedure calls, now surround the call to stateFilter in opSplittin.f90.

All updates were organizational in nature and tested with the laugh tests and WRR cases. Both output and resource usage remained unchanged.

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] closes #xxx (identify the issue associated with this PR)
- [X] tests passed
- [ ] new tests added
- [ ] science test figures
- [ ] checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] ReleaseNotes entry
