### PR TITLE
Simplfiy call to indexSplit in opSplittin using object-oriented methods

### DIFF
--- a/build/source/dshare/data_types.f90
+++ b/build/source/dshare/data_types.f90
@@ -594,6 +594,25 @@ MODULE data_types
  end type out_type_stateFilter
  ! ** end stateFilter
 
+ ! ** indexSplit
+ type, public :: in_type_indexSplit  ! class for intent(in) arguments in indexSplit call
+   integer(i4b)             :: nSnow                       ! intent(in): number of snow layers
+   integer(i4b)             :: nSoil                       ! intent(in): number of soil layers
+   integer(i4b)             :: nLayers                     ! intent(in): total number of layers
+   integer(i4b)             :: nSubset                     ! intent(in): number of states in the subset
+  contains
+   procedure :: initialize => initialize_in_indexSplit
+ end type in_type_indexSplit
+
+ type, public :: out_type_indexSplit ! class for intent(out) arguments in indexSplit call
+   integer(i4b)             :: err                         ! intent(out): error code
+   character(:),allocatable :: cmessage                    ! intent(out): error message
+  contains
+   procedure :: finalize   => finalize_out_indexSplit
+ end type out_type_indexSplit
+ ! ** end indexSplit
+
+
  ! ** varSubstep
  type, public :: in_type_varSubstep  ! class for intent(in) arguments in varSubstep call
    real(rkind)              :: dt                          ! intent(in): time step (s)
@@ -1287,7 +1306,7 @@ contains
  end subroutine initialize_in_stateFilter
 
  subroutine finalize_out_stateFilter(out_stateFilter,nSubset,err,cmessage)
-  class(out_type_stateFilter),intent(in) :: out_stateFilter   ! class object for intent(in) stateFilter arguments
+  class(out_type_stateFilter),intent(in) :: out_stateFilter   ! class object for intent(out) stateFilter arguments
   integer(i4b),intent(out)               :: nSubset           ! intent(out): number of selected state variables for a given split
   integer(i4b),intent(out)               :: err               ! intent(out): error code
   character(*),intent(out)               :: cmessage          ! intent(out): error message
@@ -1296,6 +1315,28 @@ contains
   cmessage = out_stateFilter % cmessage                       ! intent(out): error message
  end subroutine finalize_out_stateFilter
  ! **** end stateFilter ****
+
+ ! **** indexSplit ****
+ subroutine initialize_in_indexSplit(in_indexSplit,nSnow,nSoil,nLayers,nSubset)
+  class(in_type_indexSplit),intent(out) :: in_indexSplit    ! class object for intent(in) indexSplit arguments
+  integer(i4b),intent(in)               :: nSnow            ! intent(in): number of snow layers
+  integer(i4b),intent(in)               :: nSoil            ! intent(in): number of soil layers
+  integer(i4b),intent(in)               :: nLayers          ! intent(in): total number of layers
+  integer(i4b),intent(in)               :: nSubset          ! intent(in): number of states in the subset
+  in_indexSplit % nSnow   = nSnow                           ! intent(in): number of snow layers          
+  in_indexSplit % nSoil   = nSoil                           ! intent(in): number of soil layers
+  in_indexSplit % nLayers = nLayers                         ! intent(in): total number of layers
+  in_indexSplit % nSubset = nSubset                         ! intent(in): number of states in the subset
+ end subroutine initialize_in_indexSplit
+
+ subroutine finalize_out_indexSplit(out_indexSplit,err,cmessage)
+  class(out_type_indexSplit),intent(in) :: out_indexSplit   ! class object for intent(out) indexSplit arguments
+  integer(i4b),intent(out)              :: err              ! intent(out): error code
+  character(*),intent(out)              :: cmessage         ! intent(out): error message
+  err      = out_indexSplit % err                           ! intent(out): error code    
+  cmessage = out_indexSplit % cmessage                      ! intent(out): error message
+ end subroutine finalize_out_indexSplit
+ ! **** end indexSplit ****
 
  ! **** varSubstep ****
  subroutine initialize_in_varSubstep(in_varSubstep,dt,dtInit,dt_min,whole_step,nSubset,&
@@ -1329,7 +1370,7 @@ contains
  end subroutine initialize_in_varSubstep
 
  subroutine initialize_io_varSubstep(io_varSubstep,firstFluxCall,fluxCount,ixSaturation)
-  class(io_type_varSubstep),intent(out) :: io_varSubstep  ! class object for intent(in) varSubstep arguments
+  class(io_type_varSubstep),intent(out) :: io_varSubstep  ! class object for intent(inout) varSubstep arguments
   logical(lgt),intent(in)               :: firstFluxCall  ! flag to indicate if we are processing the first flux call
   type(var_ilength),intent(in)          :: fluxCount      ! number of times fluxes are updated (should equal nsubstep)
   integer(i4b),intent(in)               :: ixSaturation   ! index of the lowest saturated layer (NOTE: only computed on the first iteration)
@@ -1341,7 +1382,7 @@ contains
  end subroutine initialize_io_varSubstep
 
  subroutine finalize_io_varSubstep(io_varSubstep,firstFluxCall,fluxCount,ixSaturation)
-  class(io_type_varSubstep),intent(in)  :: io_varSubstep  ! class object for intent(in) varSubstep arguments
+  class(io_type_varSubstep),intent(in)  :: io_varSubstep  ! class object for intent(inout) varSubstep arguments
   logical(lgt),intent(out)              :: firstFluxCall  ! flag to indicate if we are processing the first flux call
   type(var_ilength),intent(out)         :: fluxCount      ! number of times fluxes are updated (should equal nsubstep)
   integer(i4b),intent(out)              :: ixSaturation   ! index of the lowest saturated layer (NOTE: only computed on the first iteration)

--- a/build/source/engine/opSplittin.f90
+++ b/build/source/engine/opSplittin.f90
@@ -96,6 +96,7 @@ USE data_types,only:&
                     zLookup,                                                   & ! lookup tables
                     model_options,                                             & ! defines the model decisions
                     in_type_statefilter,out_type_statefilter,                  & ! classes for stateFilter objects
+                    in_type_indexSplit,out_type_indexSplit,                    & ! classes for indexSplit objects
                     in_type_varSubstep,io_type_varSubstep,out_type_varSubstep    ! classes for varSubstep objects
 
 ! look-up values for the numerical method
@@ -293,6 +294,7 @@ subroutine opSplittin(&
   ! ------------------------ classes for subroutine arguments (classes defined in data_types module) ------------------------
   !      ** intent(in) arguments **         ||       ** intent(inout) arguments **        ||      ** intent(out) arguments **
   type(in_type_stateFilter) :: in_stateFilter;                                            type(out_type_stateFilter) :: out_stateFilter; ! stateFilter arguments
+  type(in_type_indexSplit)  :: in_indexSplit;                                             type(out_type_indexSplit)  :: out_indexSplit;  ! indexSplit arguments
   type(in_type_varSubstep)  :: in_varSubstep;  type(io_type_varSubstep) :: io_varSubstep; type(out_type_varSubstep)  :: out_varSubstep;  ! varSubstep arguments
 
   ! ---------------------------------------------------------------------------------------
@@ -496,10 +498,9 @@ subroutine opSplittin(&
                 ! * assemble vectors for a given split...
                 ! ---------------------------------------
                 ! get indices for a given split
-                call indexSplit(stateMask,                   & ! intent(in)    : logical vector (.true. if state is in the subset)
-                                nSnow,nSoil,nLayers,nSubset, & ! intent(in)    : number of snow and soil layers, and total number of layers
-                                indx_data,                   & ! intent(inout) : index data structure
-                                err,cmessage)                  ! intent(out)   : error control
+                call initialize_indexSplit
+                call indexSplit(in_indexSplit,stateMask,indx_data,out_indexSplit)
+                call finalize_indexSplit
                 if(err/=0)then; message=trim(message)//trim(cmessage); return; endif
 
                 ! -----
@@ -889,6 +890,16 @@ subroutine opSplittin(&
   subroutine finalize_stateFilter
    call out_stateFilter % finalize(nSubset,err,cmessage)
   end subroutine finalize_stateFilter
+
+  ! **** indexSplit ****
+  subroutine initialize_indexSplit
+   call in_indexSplit % initialize(nSnow,nSoil,nLayers,nSubset)
+  end subroutine initialize_indexSplit
+
+  subroutine finalize_indexSplit
+   call out_indexSplit % finalize(err,cmessage)
+  end subroutine finalize_indexSplit
+  ! **** end indexSplit ****
 
   ! **** varSubstep ****
   subroutine initialize_varSubstep


### PR DESCRIPTION
Hi @ashleymedin - This PR applies object-oriented methods to simplify the call to indexSplit in opSplittin. New classes were created in data_types.f90, and subroutines that handle the initialize and finalize steps for indexSplit have been added to the contains block of opSplittin. The changes have increased modularization and reduced the syntax for the indexSplit call.

These updates are organizational in nature and do not impact code output or resource use (tested with laugh and WRR tests).

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] closes #xxx (identify the issue associated with this PR)
- [x] tests passed
- [ ] new tests added
- [ ] science test figures
- [ ] checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] ReleaseNotes entry
