### PR TITLE
Refactoring updates for opSplittin

### DIFF
--- a/build/source/engine/opSplittin.f90
+++ b/build/source/engine/opSplittin.f90
@@ -328,16 +328,13 @@ subroutine opSplittin(&
             if (return_flag.eqv..true.) return ! return if error occurs during initialization
 
             stateSplit: do iStateSplit=1,nStateSplit ! loop through layers (NOTE: nStateSplit=1 for the vector solution, hence no looping)
- 
+
               ! -----
               ! * define state subsets for a given split...
               ! -------------------------------------------
 
-              ! get the mask for the state subset
-              call initialize_stateFilter
-              call stateFilter(in_stateFilter,indx_data,stateMask,out_stateFilter)
-              call finalize_stateFilter
-              if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! error control
+              call update_stateFilter ! get the mask for the state subset
+              if (return_flag.eqv..true.) return ! return for a non-zero error code
 
               ! check that state variables exist
               if (nSubset==0) cycle domainSplit
@@ -760,6 +757,15 @@ subroutine opSplittin(&
      end select
    end if
   end subroutine try_other_solution_methods 
+
+  subroutine update_stateFilter
+   ! *** Get the mask for the state subset ***
+   return_flag=.false. ! initialize flag
+   call initialize_stateFilter
+   call stateFilter(in_stateFilter,indx_data,stateMask,out_stateFilter)
+   call finalize_stateFilter
+   if (err/=0) then; message=trim(message)//trim(cmessage); return_flag=.true.; return; end if  ! error control
+  end subroutine update_stateFilter
 
   subroutine save_recover
    ! save/recover copies of prognostic variables


### PR DESCRIPTION
Hi @ashleymedin - This PR contains refactoring updates for the opSplittin subroutine that makes the code more concise, modular, and easier to understand. Certain code blocks with related operations have been migrated to new subroutines in the contains block of opSplittin (e.g., update_fluxMask). Hopefully, this makes big picture ideas clearer in the main routine, without loss of fine details (which are now in the new subroutines).

The associate statements have also been simplified. They are no longer required in the main body of opSplittin. A few associate statements appear in the subroutines called within opSplittin, but the associate statements occur over short blocks. Many of the original associate statements were no longer needed after modularizing things into component subroutines.

This PR is cosmetic and organizational in nature and does not impact output or computational resource use. This was confirmed using the test suite (laugh + WRR cases).

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] closes #xxx (identify the issue associated with this PR)
- [x] tests passed
- [ ] new tests added
- [ ] science test figures
- [ ] checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] ReleaseNotes entry
