### PR TITLE
Hotfix for error message issue in varSubstep.

### DIFF
--- a/build/source/engine/varSubstep.f90
+++ b/build/source/engine/varSubstep.f90
@@ -187,6 +187,9 @@ subroutine varSubstep(&
   real(rkind)                        :: sumSoilCompress               ! sum of total soil compression
   real(rkind),allocatable            :: sumLayerCompress(:)           ! sum of soil compression by layer
   ! ---------------------------------------------------------------------------------------
+  ! initialize error control
+  out_varSubstep % err=0; out_varSubstep % cmessage='varSubstep/'
+  ! ---------------------------------------------------------------------------------------
   ! point to variables in the data structures
   ! ---------------------------------------------------------------------------------------
   globalVars: associate(&
@@ -240,9 +243,6 @@ subroutine varSubstep(&
     message           => out_varSubstep % cmessage                  & ! intent(out): error message
     )  ! end association with variables in the data structures
     ! *********************************************************************************************************************************************************
-   
-    ! initialize error control
-    err=0; message='varSubstep/'
 
     ! initialize flag for the success of the substepping
     failedMinimumStep=.false.


### PR DESCRIPTION
Hi @ashleymedin - here's the fix to the error message problem. Turns out that the data component used to handle the character string for the message variable in varSubstep was not being allocated. I moved the first error control initialization above the associate block and used the full class object names. The allocatable character component out_varSubstep % cmessage is now allocated during the first assignment statement, as intended. Previously, the first assignment was performed using the associate name, but I don't think allocation is allowed using associate names.

This fix was tested using a subset of the full test suite (WRR figure 9). Please let me know if you experience any problems.

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] closes #xxx (identify the issue associated with this PR)
- [x] tests passed
- [ ] new tests added
- [ ] science test figures
- [ ] checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] ReleaseNotes entry
