### PR TITLE
Expanded the instructions for the installation of SUNDIALS

### DIFF
--- a/build/cmake/build.pc.bash
+++ b/build/cmake/build.pc.bash
@@ -22,5 +22,5 @@
 #export FLAGS_OPT="-m64;-I"${MKLROOT}/include";-flto=1;-fuse-linker-plugin"   # optional compiler flags -- Intel oneMKL builds
 
 # CMake Commands (build type controlled using DCMAKE_BUILD_TYPE)
-cmake -B ../cmake_build -S . -DCMAKE_BUILD_TYPE=BE
+cmake -B ../cmake_build -S . -DCMAKE_BUILD_TYPE=Sundials
 cmake --build ../cmake_build --target all

--- a/docs/README_not_ngen.md
+++ b/docs/README_not_ngen.md
@@ -23,6 +23,7 @@ To fetch and check out the latest revision (for the [currently used branch](#vie
 
 ## Building Libraries
 
+### Solver options in SUMMA build scripts
 First, cd into the cmake directory in summa, without Actors:
 
     cd summa/build/cmake
@@ -31,36 +32,53 @@ or with Actors:
 
     cd summa/build/summa/build/cmake
 
-If you want to use Sundials IDA or BE Kinsol, set -DCMAKE_BUILD_TYPE=Sundials* in the build script instead of BE*.  Then, before summa can be built, Sundials needs to be installed. 
-Download the latest release of IDA solver from SUNDIALS package in https://computing.llnl.gov/projects/sundials/sundials-software, using X.Y.Z as the latest version
+If you want to use Sundials IDA or BE Kinsol, set -DCMAKE_BUILD_TYPE=Sundials* in the build script instead of BE*.  Then, before summa can be built, Sundials needs to be installed.
 
-    wget "https://github.com/LLNL/sundials/releases/download/vX.Y.Z/sundials-X.Y.Z.tar.gz"
-
-Extract the corresponding compressed file, rename
-
-    tar -xzf sundials-X.Y.Z.tar.gz && mv sundials-X.Y.Z sundials-software
-
-We suggest you periodically update to the latest version-- you can also install through github 
-    git clone https://github.com/LLNL/sundials.git sundials-software
-    cd sundials-software
-    git fetch --all --tags --prune
-    git checkout tags/vX.Y.Z
+### Installing SUNDIALS
+0. For reference, let the main summa directory be contained in the folder `top_dir`
+    - e.g., summa exectuables would be located within `top_dir/summa/bin`
     
-An example build_cmake file is at summa/build/cmake_external/build_cmakeSundials.bash which you can copy to builddir as build_cmake. Then, enter the buildir and run
+2. Download the file `sundials-X.Y.Z.tar.gz` (where X.Y.Z is the latest SUNDIALS version) at https://github.com/LLNL/sundials/releases/latest 
+ 
+3. Move `sundials-X.Y.Z.tar.gz` into `top_dir`
+    - `$ ls top_dir` should include `summa sundials-X.Y.Z.tar.gz` 
 
-    cd sundials/buildir
-    ./build_cmake
-    make
-    make install
+4. Extract the corresponding compressed file and rename
+    1. `$ cd top_dir`
+    2. `$ tar -xzf sundials-X.Y.Z.tar.gz && mv sundials-X.Y.Z sundials-software`
+    3. `sundials-X.Y.Z.tar.gz` can now be removed to save space if desired
+
+5. Create new empty directories to prep for SUNDIALS installation
+    1. within `top_dir`: `$ mkdir sundials`
+    2. `$ cd sundials`
+    3. `$ mkdir builddir instdir`
+
+6. Copy CMake build script from SUMMA files to properly configure SUNDIALS
+    1. `$ cd builddir`
+    2. `$ cp ../../summa/build/cmake_external/build_cmakeSundials.bash .`
+
+7. Build SUNDIALS configured for SUMMA
+    1. within `builddir`: `$ ./build_cmakeSundials.bash`
+    2. `$ make`
+    3. `$ make install`
+
+
+We suggest you periodically update to the latest version. It is also possible to install using Git: 
+ 
+    $ git clone https://github.com/LLNL/sundials.git sundials-software
+    $ cd sundials-software
+    $ git fetch --all --tags --prune
+    $ git checkout tags/vX.Y.Z     
     
 Note if you need to recompile after a system upgrade, delete the contents of sundials/instdir and sundials/buildir EXCEPT sundials/buildir/build_cmake before building and installing.
 
-
 Note that when there is an existing directory, it may sometimes be necessary to clear it and regenerate, especially if any changes were made to the CMakeLists.txt file.
+
+### Building SUMMA
 
 After there is build system directory, the shared library can be built using the `summabmi` CMake target. For example, the SummaSundials shared library file (i.e., the build config's `summabmi` target) can be built using:
 
-    cmake --build ../cmake_build --target all
+    $ cmake --build ../cmake_build --target all
 
 This will build a `cmake_build/libsummabmi.<version>.<ext>` file, where the version is configured within the CMake config, and the extension depends on the local machine's operating system.    
 


### PR DESCRIPTION
Hi @ashleymedin - This PR adds some details to the instructions for installing SUNDIALS configured for SUMMA. The main goal was to clarify the directory structure needed and to avoid having to look in the SUNDIALS documentation. 

I removed the wget commands in favour of a website link that automatically goes to the latest release on GitHub. I originally tried to get wget to automatically retrieve the latest release, but it did not work because the tag number is also included in the tar file. 

There are no SUMMA code changes. I have updated the build.pc.bash script to now use the SUNDIALS build option by default instead of BE.

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] Closes #xxx (identify the issue associated with this PR)
- [ ] Code passes standard test cases (results are either bit-for-bit identical, or differences are explained in the PR comment)
- [ ] New tests added (describe which tests were performed to test the changes)
- [ ] Science test figures (add figures to PR comment and describe the tests)
- [ ] Checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] Describe the change in the release notes (use  `./summa/docs/whats-new.md`)