### PR TITLE
Refactoring updates for summa_driver.f90 and opSplittin.f90

### DIFF
--- a/build/source/driver/summa_driver.f90
+++ b/build/source/driver/summa_driver.f90
@@ -64,103 +64,23 @@ program summa_driver
   integer(i4b)                       :: err=0                      ! error code
   character(len=1024)                :: message=''                 ! error message
 
-!!! -------------------- Begin Initialize -------------------- !!!
+  ! Initialize
   call initialize_summa_driver
 
-!  ! *****************************************************************************
-!  ! * preliminaries
-!  ! *****************************************************************************
-!
-!  ! allocate space for the master summa structure
-!  allocate(summa1_struc(n), stat=err)
-!  if(err/=0) call stop_program(1, 'problem allocating master summa structure')
+  ! Update
+  call update_summa_driver
 
-!  ! *****************************************************************************
-!  ! * model setup/initialization
-!  ! *****************************************************************************
-!
-!  ! declare and allocate summa data structures and initialize model state to known values
-!  call summa_initialize(summa1_struc(n), err, message)
-!  call handle_err(err, message)
-!
-!  ! initialize parameter data structures (e.g. vegetation and soil parameters)
-!  call summa_paramSetup(summa1_struc(n), err, message)
-!  call handle_err(err, message)
-!
-!  ! read restart data and reset the model state
-!  call summa_readRestart(summa1_struc(n), err, message)
-!  call handle_err(err, message)
-
-!#ifdef OPENWQ_ACTIVE
-!  call openwq_init(err)
-!  if (err /= 0) call stop_program(1, 'Problem Initializing OpenWQ')
-!#endif
-!!! -------------------- End Initialize -------------------- !!!
-
-!!! -------------------- Begin Update -------------------- !!!
-  ! *****************************************************************************
-  ! * model simulation
-  ! *****************************************************************************
-  ! loop through time
-  do modelTimeStep=1,numtim
-
-    ! read model forcing data
-    call summa_readForcing(modelTimeStep, summa1_struc(n), err, message)
-    call handle_err(err, message)
-
-#ifdef OPENWQ_ACTIVE
-    call openwq_run_time_start(summa1_struc(n)) ! Passing state volumes to openWQ
-#endif
-
-    if (mod(modelTimeStep, print_step_freq) == 0)then
-      print *, 'step ---> ', modelTimeStep
-    endif
-
-    ! run the summa physics for one time step
-    call summa_runPhysics(modelTimeStep, summa1_struc(n), err, message)
-    call handle_err(err, message)
-
-#ifdef OPENWQ_ACTIVE
-    call openwq_run_space_step(summa1_struc(n)) ! Passing fluxes to openWQ
-#endif
-
-    ! write the model output
-    call summa_writeOutputFiles(modelTimeStep, summa1_struc(n), err, message)
-    call handle_err(err, message)
-
-#ifdef OPENWQ_ACTIVE
-    call openwq_run_time_end(summa1_struc(n))
-#endif
-
-  end do  ! looping through time
-!!! -------------------- End Update -------------------- !!!
-
-!!! -------------------- Begin Finalize -------------------- !!!
+  ! Finalize
   call finalize_summa_driver
-
-!  ! successful end
-!  call stop_program(0, 'finished simulation successfully.')
-!
-!  ! to prevent exiting before HDF5 has closed
-!  call sleep(2)
-!!! -------------------- End Finalize -------------------- !!!
 
 contains
 
   subroutine initialize_summa_driver
    ! *** Initial operations for SUMMA driver program ***
 
-   ! *****************************************************************************
-   ! * preliminaries
-   ! *****************************************************************************
-
    ! allocate space for the master summa structure
    allocate(summa1_struc(n), stat=err)
    if(err/=0) call stop_program(1, 'problem allocating master summa structure')
-
-   ! *****************************************************************************
-   ! * model setup/initialization
-   ! *****************************************************************************
 
    ! declare and allocate summa data structures and initialize model state to known values
    call summa_initialize(summa1_struc(n), err, message)
@@ -183,6 +103,38 @@ contains
   subroutine update_summa_driver
    ! *** Update operations for SUMMA driver program ***
 
+   ! loop through time
+   do modelTimeStep=1,numtim
+ 
+     ! read model forcing data
+     call summa_readForcing(modelTimeStep, summa1_struc(n), err, message)
+     call handle_err(err, message)
+ 
+#ifdef OPENWQ_ACTIVE
+     call openwq_run_time_start(summa1_struc(n)) ! Passing state volumes to openWQ
+#endif
+ 
+     if (mod(modelTimeStep, print_step_freq) == 0)then
+       print *, 'step ---> ', modelTimeStep
+     endif
+ 
+     ! run the summa physics for one time step
+     call summa_runPhysics(modelTimeStep, summa1_struc(n), err, message)
+     call handle_err(err, message)
+ 
+#ifdef OPENWQ_ACTIVE
+     call openwq_run_space_step(summa1_struc(n)) ! Passing fluxes to openWQ
+#endif
+ 
+     ! write the model output
+     call summa_writeOutputFiles(modelTimeStep, summa1_struc(n), err, message)
+     call handle_err(err, message)
+ 
+#ifdef OPENWQ_ACTIVE
+     call openwq_run_time_end(summa1_struc(n))
+#endif
+ 
+   end do  ! looping through time
   end subroutine update_summa_driver
 
   subroutine finalize_summa_driver

--- a/build/source/driver/summa_driver.f90
+++ b/build/source/driver/summa_driver.f90
@@ -19,10 +19,9 @@
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 program summa_driver
-  ! driver program for summa simulations
-  ! *****************************************************************************
-  ! * use desired modules
-  ! *****************************************************************************
+  ! **** Driver program for SUMMA simulations ****
+
+  ! * module access *
   ! data types
   USE nrtype                                                  ! variable types, etc.
   USE summa_type, only: summa1_type_dec                       ! master summa data type
@@ -41,7 +40,7 @@ program summa_driver
   USE globalData, only: numtim                                ! number of model time steps
   USE globalData, only: print_step_freq
 
-!   ! OpenWQ coupling
+  ! OpenWQ coupling
 #ifdef OPENWQ_ACTIVE
   USE summa_openwq,only:openwq_init
   USE summa_openwq,only:openwq_run_time_start
@@ -51,9 +50,7 @@ program summa_driver
 
   implicit none
 
-  ! *****************************************************************************
-  ! * variable definitions
-  ! *****************************************************************************
+  ! * driver variables *
   ! define the master summa data structure
   type(summa1_type_dec), allocatable :: summa1_struc(:)
   ! define parameters for the model simulation
@@ -80,7 +77,7 @@ contains
 
    ! allocate space for the master summa structure
    allocate(summa1_struc(n), stat=err)
-   if(err/=0) call stop_program(1, 'problem allocating master summa structure')
+   if (err/=0) call stop_program(1, 'problem allocating master summa structure')
 
    ! declare and allocate summa data structures and initialize model state to known values
    call summa_initialize(summa1_struc(n), err, message)
@@ -114,9 +111,9 @@ contains
      call openwq_run_time_start(summa1_struc(n)) ! Passing state volumes to openWQ
 #endif
  
-     if (mod(modelTimeStep, print_step_freq) == 0)then
+     if (mod(modelTimeStep, print_step_freq) == 0) then
        print *, 'step ---> ', modelTimeStep
-     endif
+     end if
  
      ! run the summa physics for one time step
      call summa_runPhysics(modelTimeStep, summa1_struc(n), err, message)
@@ -134,7 +131,7 @@ contains
      call openwq_run_time_end(summa1_struc(n))
 #endif
  
-   end do  ! looping through time
+   end do  ! end looping through time
   end subroutine update_summa_driver
 
   subroutine finalize_summa_driver

--- a/build/source/driver/summa_driver.f90
+++ b/build/source/driver/summa_driver.f90
@@ -64,35 +64,40 @@ program summa_driver
   integer(i4b)                       :: err=0                      ! error code
   character(len=1024)                :: message=''                 ! error message
 
-  ! *****************************************************************************
-  ! * preliminaries
-  ! *****************************************************************************
+!!! -------------------- Begin Initialize -------------------- !!!
+  call initialize_summa_driver
 
-  ! allocate space for the master summa structure
-  allocate(summa1_struc(n), stat=err)
-  if(err/=0) call stop_program(1, 'problem allocating master summa structure')
+!  ! *****************************************************************************
+!  ! * preliminaries
+!  ! *****************************************************************************
+!
+!  ! allocate space for the master summa structure
+!  allocate(summa1_struc(n), stat=err)
+!  if(err/=0) call stop_program(1, 'problem allocating master summa structure')
 
-  ! *****************************************************************************
-  ! * model setup/initialization
-  ! *****************************************************************************
+!  ! *****************************************************************************
+!  ! * model setup/initialization
+!  ! *****************************************************************************
+!
+!  ! declare and allocate summa data structures and initialize model state to known values
+!  call summa_initialize(summa1_struc(n), err, message)
+!  call handle_err(err, message)
+!
+!  ! initialize parameter data structures (e.g. vegetation and soil parameters)
+!  call summa_paramSetup(summa1_struc(n), err, message)
+!  call handle_err(err, message)
+!
+!  ! read restart data and reset the model state
+!  call summa_readRestart(summa1_struc(n), err, message)
+!  call handle_err(err, message)
 
-  ! declare and allocate summa data structures and initialize model state to known values
-  call summa_initialize(summa1_struc(n), err, message)
-  call handle_err(err, message)
+!#ifdef OPENWQ_ACTIVE
+!  call openwq_init(err)
+!  if (err /= 0) call stop_program(1, 'Problem Initializing OpenWQ')
+!#endif
+!!! -------------------- End Initialize -------------------- !!!
 
-  ! initialize parameter data structures (e.g. vegetation and soil parameters)
-  call summa_paramSetup(summa1_struc(n), err, message)
-  call handle_err(err, message)
-
-  ! read restart data and reset the model state
-  call summa_readRestart(summa1_struc(n), err, message)
-  call handle_err(err, message)
-
-#ifdef OPENWQ_ACTIVE
-  call openwq_init(err)
-  if (err /= 0) call stop_program(1, 'Problem Initializing OpenWQ')
-#endif
-
+!!! -------------------- Begin Update -------------------- !!!
   ! *****************************************************************************
   ! * model simulation
   ! *****************************************************************************
@@ -128,11 +133,65 @@ program summa_driver
 #endif
 
   end do  ! looping through time
+!!! -------------------- End Update -------------------- !!!
 
-  ! successful end
-  call stop_program(0, 'finished simulation successfully.')
+!!! -------------------- Begin Finalize -------------------- !!!
+  call finalize_summa_driver
 
-  ! to prevent exiting before HDF5 has closed
-  call sleep(2)
+!  ! successful end
+!  call stop_program(0, 'finished simulation successfully.')
+!
+!  ! to prevent exiting before HDF5 has closed
+!  call sleep(2)
+!!! -------------------- End Finalize -------------------- !!!
+
+contains
+
+  subroutine initialize_summa_driver
+   ! *** Initial operations for SUMMA driver program ***
+
+   ! *****************************************************************************
+   ! * preliminaries
+   ! *****************************************************************************
+
+   ! allocate space for the master summa structure
+   allocate(summa1_struc(n), stat=err)
+   if(err/=0) call stop_program(1, 'problem allocating master summa structure')
+
+   ! *****************************************************************************
+   ! * model setup/initialization
+   ! *****************************************************************************
+
+   ! declare and allocate summa data structures and initialize model state to known values
+   call summa_initialize(summa1_struc(n), err, message)
+   call handle_err(err, message)
+
+   ! initialize parameter data structures (e.g. vegetation and soil parameters)
+   call summa_paramSetup(summa1_struc(n), err, message)
+   call handle_err(err, message)
+
+   ! read restart data and reset the model state
+   call summa_readRestart(summa1_struc(n), err, message)
+   call handle_err(err, message)
+
+#ifdef OPENWQ_ACTIVE
+   call openwq_init(err)
+   if (err /= 0) call stop_program(1, 'Problem Initializing OpenWQ')
+#endif
+  end subroutine initialize_summa_driver
+
+  subroutine update_summa_driver
+   ! *** Update operations for SUMMA driver program ***
+
+  end subroutine update_summa_driver
+
+  subroutine finalize_summa_driver
+   ! *** Final operations for SUMMA driver program ***
+   ! successful end
+   call stop_program(0, 'finished simulation successfully.')
+
+   ! to prevent exiting before HDF5 has closed
+   call sleep(2)
+  end subroutine finalize_summa_driver
 
 end program summa_driver

--- a/build/source/engine/opSplittin.f90
+++ b/build/source/engine/opSplittin.f90
@@ -28,14 +28,6 @@ USE globalData,only:globalPrintFlag
 
 ! access missing values
 USE globalData,only:integerMissing   ! missing integer
-USE globalData,only:realMissing      ! missing double precision number
-USE globalData,only:quadMissing      ! missing quadruple precision number
-
-! domain types
-USE globalData,only:iname_cas        ! named variables for the canopy air space
-USE globalData,only:iname_veg        ! named variables for vegetation
-USE globalData,only:iname_snow       ! named variables for snow
-USE globalData,only:iname_soil       ! named variables for soil
 
 ! state variable type
 USE globalData,only:iname_nrgCanair  ! named variable defining the energy of the canopy air space
@@ -50,21 +42,15 @@ USE globalData,only:iname_lmpLayer   ! named variable defining the liquid matric
 USE globalData,only:iname_watAquifer ! named variable defining the water storage in the aquifer
 
 ! global metadata
-USE globalData,only:flux_meta                        ! metadata on the model fluxes
-USE globalData,only:diag_meta                        ! metadata on the model diagnostic variables
-USE globalData,only:prog_meta                        ! metadata on the model prognostic variables
-USE globalData,only:deriv_meta                       ! metadata on the model derivatives
-USE globalData,only:flux2state_orig                  ! metadata on flux-to-state mapping (original state variables)
-USE globalData,only:flux2state_liq                   ! metadata on flux-to-state mapping (liquid water state variables)
+USE globalData,only:flux_meta        ! metadata on the model fluxes
+USE globalData,only:diag_meta        ! metadata on the model diagnostic variables
+USE globalData,only:prog_meta        ! metadata on the model prognostic variables
+USE globalData,only:deriv_meta       ! metadata on the model derivatives
+USE globalData,only:flux2state_orig  ! metadata on flux-to-state mapping (original state variables)
+USE globalData,only:flux2state_liq   ! metadata on flux-to-state mapping (liquid water state variables)
   
 ! provide access to indices that define elements of the data structures
-USE var_lookup,only:iLookATTR        ! named variables for structure elements
-USE var_lookup,only:iLookTYPE        ! named variables for structure elements
-USE var_lookup,only:iLookPROG        ! named variables for structure elements
-USE var_lookup,only:iLookDIAG        ! named variables for structure elements
 USE var_lookup,only:iLookFLUX        ! named variables for structure elements
-USE var_lookup,only:iLookFORCE       ! named variables for structure elements
-USE var_lookup,only:iLookPARAM       ! named variables for structure elements
 USE var_lookup,only:iLookINDEX       ! named variables for structure elements
 USE var_lookup,only:iLookDECISIONS   ! named variables for elements of the decision structure
 
@@ -125,12 +111,6 @@ integer(i4b),parameter  :: subDomain=2                ! sub domain (veg, snow, s
 integer(i4b),parameter  :: nStateTypes=2              ! number of state types (energy, water)
 integer(i4b),parameter  :: nDomains=4                 ! number of domains (vegetation, snow, soil, and aquifer)
 
-! control parameters
-real(rkind),parameter   :: valueMissing=-9999._rkind     ! missing value
-real(rkind),parameter   :: verySmall=1.e-12_rkind        ! a very small number (used to check consistency)
-real(rkind),parameter   :: veryBig=1.e+20_rkind          ! a very big number
-real(rkind),parameter   :: dx = 1.e-8_rkind              ! finite difference increment
-
 ! class definitions
 
 type, public :: split_select_type  ! class for selecting operator splitting methods
@@ -189,7 +169,6 @@ end type split_select_type
 
 contains
 
-
 ! **********************************************************************************************************
 ! public subroutine opSplittin: run the coupled energy-mass model for one timestep
 !
@@ -235,8 +214,6 @@ subroutine opSplittin(&
   ! population/extraction of state vectors
   USE indexState_module,only:indexSplit                ! get state indices
   USE varSubstep_module,only:varSubstep                ! complete substeps for a given split
-  ! identify name of variable type (for error message)
-  USE get_ixName_module,only:get_varTypeName           ! to access type strings for error messages
   implicit none
   ! ---------------------------------------------------------------------------------------
   ! * dummy variables

--- a/build/source/engine/opSplittin.f90
+++ b/build/source/engine/opSplittin.f90
@@ -336,7 +336,6 @@ subroutine opSplittin(&
   logical(lgt)                    :: exit_split_select,cycle_split_select ! control for split_select loop
   logical(lgt)                    :: exit_coupling,exit_stateThenDomain,exit_solution
   logical(lgt)                    :: cycle_coupling,cycle_stateThenDomain,cycle_domainSplit,cycle_solution
-  integer(i4b),parameter          :: maxSplit=500       ! >= max number of splitting methods (controls upper limit of split_select loop)               
   ! ------------------------ classes for subroutine arguments (classes defined in data_types module) ------------------------
   !      ** intent(in) arguments **         ||       ** intent(inout) arguments **        ||      ** intent(out) arguments **
   type(in_type_indexSplit)  :: in_indexSplit;                                             type(out_type_indexSplit)  :: out_indexSplit;  ! indexSplit arguments
@@ -416,7 +415,11 @@ subroutine opSplittin(&
 
   subroutine finalize_split_solve
    ! *** Final operations for solving the selected split ***
+   integer(i4b),parameter          :: maxSplit=500       ! >= max number of splitting methods (controls upper limit of split_select loop)               
    call finalize_split_stateTypeSplitting; if (exit_split_select.or.return_flag) return
+   if (split_select % iSplit.ge.maxSplit) then ! check for errors - execute fail-safe if needed
+    err=20; message=trim(message)//'split_select loop exceeded max number of iterations'; return_flag=.true.; return 
+   end if
   end subroutine finalize_split_solve
 
   subroutine initialize_split
@@ -617,9 +620,6 @@ subroutine opSplittin(&
     call split_select % advance_ixCoupling
    end if
    call split_select % advance_iSplit ! advance iteration counter for split_select_loop
-   if (split_select % iSplit.ge.maxSplit) then ! check for errors
-    err=20; message=trim(message)//'split_select loop exceeded max number of iterations'; return_flag=.true.; return 
-   end if
   end subroutine finalize_split_stateTypeSplitting
 
   subroutine finalize_split_coupling

--- a/build/source/engine/opSplittin.f90
+++ b/build/source/engine/opSplittin.f90
@@ -249,6 +249,7 @@ subroutine opSplittin(&
   real(rkind),intent(in)          :: dt                             ! time step (seconds)
   real(rkind),intent(in)          :: whole_step                     ! length of whole step for surface drainage and average flux
   logical(lgt),intent(in)         :: firstSubStep                   ! flag to indicate if we are processing the first sub-step
+  logical(lgt),intent(in)         :: firstInnerStep                 ! flag to denote if the first time step in maxstep subStep
   logical(lgt),intent(in)         :: computeVegFlux                 ! flag to indicate if we are computing fluxes over vegetation (.false. means veg is buried with snow)
   ! input/output: data structures
   type(var_i),intent(in)          :: type_data                      ! type of vegetation and soil
@@ -327,15 +328,13 @@ subroutine opSplittin(&
   logical(lgt)                    :: failedMinimumStep              ! flag to denote failure of substepping for a given split
   integer(i4b)                    :: ixSaturation                   ! index of the lowest saturated layer (NOTE: only computed on the first iteration)
   integer(i4b)                    :: nCoupling
-  logical(lgt)                    :: firstInnerStep                 ! flag to denote if the first time step in maxstep subStep
   ! mean steps 
   real(rkind)                     :: mean_step_state                ! mean step over the state (with or without domain splits)
   real(rkind)                     :: mean_step_solution             ! mean step for a solution (scalar or vector)
   logical(lgt)                    :: addFirstFlux                   ! flag to add the first flux to the mask
   ! splitting method control variables
-  logical(lgt)                    :: exit_split_select,cycle_split_select ! control for split_select loop
-  logical(lgt)                    :: exit_coupling,exit_stateThenDomain,exit_solution
-  logical(lgt)                    :: cycle_coupling,cycle_stateThenDomain,cycle_domainSplit,cycle_solution
+  logical(lgt)                    :: exit_split_select,exit_coupling,exit_stateThenDomain,exit_solution
+  logical(lgt)                    :: cycle_split_select,cycle_coupling,cycle_stateThenDomain,cycle_domainSplit,cycle_solution
   ! ------------------------ classes for subroutine arguments (classes defined in data_types module) ------------------------
   !      ** intent(in) arguments **         ||       ** intent(inout) arguments **        ||      ** intent(out) arguments **
   type(in_type_indexSplit)  :: in_indexSplit;                                             type(out_type_indexSplit)  :: out_indexSplit;  ! indexSplit arguments

--- a/build/source/engine/opSplittin.f90
+++ b/build/source/engine/opSplittin.f90
@@ -358,7 +358,7 @@ subroutine opSplittin(&
    call initialize_split_coupling; if (return_flag) return ! prep for first iteration of update_opSplittin 
   end subroutine initialize_opSplittin
 
-  subroutine update_opSplittin
+  subroutine update_opSplittin_OG ! -------------------------------------------------- SJT: Take out 
    ! *** Update operations for opSplittin ***
    split_select_loop: do                         ! coupling begins
      call initialize_split_stateTypeSplitting; if (exit_split_select) exit split_select_loop; if (return_flag) return
@@ -389,12 +389,95 @@ subroutine opSplittin(&
      end if ! stateTypeSplitting ends
      call finalize_split_stateTypeSplitting; if (exit_split_select) exit split_select_loop; if (return_flag) return
    end do split_select_loop ! coupling ends
+  end subroutine update_opSplittin_OG
+
+  subroutine update_opSplittin
+   ! *** Update operations for opSplittin ***
+   split_select_loop: do                         ! coupling begins
+
+     call initialize_split_solve; if (exit_split_select) exit split_select_loop; if (return_flag) return
+
+     call update_split_solve;     if (return_flag) return; if (cycle_split_select) cycle split_select_loop
+
+     call finalize_split_solve;   if (exit_split_select) exit split_select_loop; if (return_flag) return
+
+     !call initialize_split_stateTypeSplitting; if (exit_split_select) exit split_select_loop; if (return_flag) return
+
+     !if (split_select % stateTypeSplitting) then ! stateTypeSplitting begins
+     !  call initialize_split_stateThenDomain
+     !  if (split_select % stateThenDomain) then  ! stateThenDomain begins
+     !    call initialize_split_domainSplit; if (return_flag) return
+     !    if (split_select % domainSplit) then    ! domainSplit begins
+     !      call initialize_split_solution
+     !      if (split_select % solution) then     ! solution begins
+     !        call initialize_split_stateSplit; if (return_flag) return 
+     !        if (split_select % stateSplit) then ! stateSplit begins
+
+     !          call initialize_split; if (return_flag) return; if (cycle_initialize_split()) cycle split_select_loop
+
+     !          call update_split;     if (return_flag) return
+
+     !          call finalize_split;   if (return_flag) return; if (cycle_finalize_split())   cycle split_select_loop
+
+     !        end if ! stateSplit ends
+     !        call finalize_split_stateSplit
+     !      end if ! solution ends
+     !      call finalize_split_solution
+     !    end if ! domainSplit ends
+     !    call finalize_split_domainSplit
+     !  end if ! stateThenDomain ends
+     !  call finalize_split_stateThenDomain;  if (return_flag) return
+     !end if ! stateTypeSplitting ends
+
+     !call finalize_split_stateTypeSplitting; if (exit_split_select) exit split_select_loop; if (return_flag) return
+
+   end do split_select_loop ! coupling ends
   end subroutine update_opSplittin
 
   subroutine finalize_opSplittin
    ! *** Final operations for opSplittin ***
    call finalize_split_coupling; if (return_flag) return
   end subroutine finalize_opSplittin
+
+  subroutine initialize_split_solve
+   ! *** Initial operations for solving the selected split ***
+   call initialize_split_stateTypeSplitting; if (exit_split_select.or.return_flag) return
+   cycle_split_select=.false. ! initialize flag for cycle control of split_select_loop
+  end subroutine initialize_split_solve
+
+  subroutine update_split_solve
+   ! *** Update operations for solving the selected split ***
+   if (split_select % stateTypeSplitting) then ! stateTypeSplitting begins
+     call initialize_split_stateThenDomain
+     if (split_select % stateThenDomain) then  ! stateThenDomain begins
+       call initialize_split_domainSplit; if (return_flag) return
+       if (split_select % domainSplit) then    ! domainSplit begins
+         call initialize_split_solution
+         if (split_select % solution) then     ! solution begins
+           call initialize_split_stateSplit; if (return_flag) return 
+           if (split_select % stateSplit) then ! stateSplit begins
+
+             call initialize_split; if (return_flag) return; if (cycle_initialize_split()) then; cycle_split_select=.true.; return; end if
+
+             call update_split;     if (return_flag) return
+
+             call finalize_split;   if (return_flag) return; if (cycle_finalize_split())   then; cycle_split_select=.true.; return; end if
+
+           end if ! stateSplit ends
+           call finalize_split_stateSplit
+         end if ! solution ends
+         call finalize_split_solution
+       end if ! domainSplit ends
+       call finalize_split_domainSplit
+     end if ! stateThenDomain ends
+     call finalize_split_stateThenDomain;  if (return_flag) return
+   end if ! stateTypeSplitting ends
+  end subroutine update_split_solve
+
+  subroutine finalize_split_solve
+   ! *** Final operations for solving the selected split ***
+   call finalize_split_stateTypeSplitting; if (exit_split_select.or.return_flag) return
+  end subroutine finalize_split_solve
 
   subroutine initialize_split
    ! *** Initialize logical masks for selected splitting method ***

--- a/build/source/engine/opSplittin.f90
+++ b/build/source/engine/opSplittin.f90
@@ -344,59 +344,81 @@ subroutine opSplittin(&
   ! -------------------------------------------------------------------------------------------------------------------------
   type(split_select_type) :: split_select ! class object for selecting operator splitting methods
 
-  ! *** Initialize Split Selector Object ***
-  call initialize_split_select;   if (return_flag) return
-  call initialize_split_coupling; if (return_flag) return 
-  split_select_loop: do                         ! coupling begins
-    call initialize_split_stateTypeSplitting; if (exit_split_select) exit split_select_loop; if (return_flag) return
-    if (split_select % stateTypeSplitting) then ! stateTypeSplitting begins
-      call initialize_split_stateThenDomain
-      if (split_select % stateThenDomain) then  ! stateThenDomain begins
-        call initialize_split_domainSplit; if (return_flag) return
-        if (split_select % domainSplit) then    ! domainSplit begins
-          call initialize_split_solution
-          if (split_select % solution) then     ! solution begins
-            call initialize_split_stateSplit; if (return_flag) return 
-            if (split_select % stateSplit) then ! stateSplit begins
-              call update_stateMask; if (return_flag) return         ! get the mask for the state subset - return for a non-zero error code
-              call validate_split                                    ! verify that the split is valid
-              if (cycle_domainSplit) cycle split_select_loop         ! if needed, proceed to next iteration of domainSplit method 
-              if (cycle_solution)    cycle split_select_loop         ! if needed, proceed to next iteration of solution method 
-              if (return_flag)       return                          ! return for a non-zero error code
-              
-              call save_recover                                      ! save/recover copies of variables and fluxes
+  call initialize_opSplittin; if (return_flag) return
 
-              call get_split_indices; if (return_flag) return        ! get indices for a given split - return for a non-zero error code
-              call update_fluxMask;   if (return_flag) return        ! define the mask for the fluxes used - return for a non-zero error code
+  call update_opSplittin;     if (return_flag) return
 
-              call solve_subset;      if (return_flag) return        ! solve variable subset for one time step - return for a positive error code
-              call assess_solution;   if (return_flag) return        ! is solution a success or failure? - return for a recovering solution
-
-              call try_other_solution_methods                        ! if solution failed to converge, try other splitting methods 
-              if (cycle_coupling)        cycle split_select_loop     ! if needed, proceed to next iteration of coupling method
-              if (cycle_stateThenDomain) cycle split_select_loop     ! if needed, proceed to next iteration of stateThenDomain method
-              if (cycle_solution)        cycle split_select_loop     ! if needed, proceed to next iteration of solution method 
-
-              call confirm_variable_updates; if (return_flag) return ! check that state variables are updated - return if error 
-
-              call success_check                                     ! check for success
-              call check_exit_stateThenDomain                        ! check exit criterion for stateThenDomain split
-              call check_exit_solution; if (return_flag) return      ! check exit criterion for solution split - return if error 
-            end if ! stateSplit ends
-            call finalize_split_stateSplit
-          end if ! solution ends
-          call finalize_split_solution
-        end if ! domainSplit ends
-        call finalize_split_domainSplit
-      end if ! stateThenDomain ends
-      call finalize_split_stateThenDomain; if (return_flag) return
-    end if ! stateTypeSplitting ends
-    call finalize_split_stateTypeSplitting; if (exit_split_select) exit split_select_loop; if (return_flag) return
-  end do split_select_loop ! coupling ends
-  call finalize_split_coupling; if (return_flag) return
+  call finalize_opSplittin;   if (return_flag) return
 
  contains
 
+  subroutine initialize_opSplittin
+   ! *** Initial operations for opSplittin ***
+   call initialize_split_select;   if (return_flag) return ! initialize split selector object (split_select)
+   call initialize_split_coupling; if (return_flag) return ! prep for first iteration of update_opSplittin 
+  end subroutine initialize_opSplittin
+
+  subroutine update_opSplittin
+   ! *** Update operations for opSplittin ***
+   split_select_loop: do                         ! coupling begins
+     call initialize_split_stateTypeSplitting; if (exit_split_select) exit split_select_loop; if (return_flag) return
+     if (split_select % stateTypeSplitting) then ! stateTypeSplitting begins
+       call initialize_split_stateThenDomain
+       if (split_select % stateThenDomain) then  ! stateThenDomain begins
+         call initialize_split_domainSplit; if (return_flag) return
+         if (split_select % domainSplit) then    ! domainSplit begins
+           call initialize_split_solution
+           if (split_select % solution) then     ! solution begins
+             call initialize_split_stateSplit; if (return_flag) return 
+             if (split_select % stateSplit) then ! stateSplit begins
+               !! create split
+               call update_stateMask; if (return_flag) return         ! get the mask for the state subset - return for a non-zero error code
+               call validate_split                                    ! verify that the split is valid
+               if (cycle_domainSplit) cycle split_select_loop         ! if needed, proceed to next iteration of domainSplit method 
+               if (cycle_solution)    cycle split_select_loop         ! if needed, proceed to next iteration of solution method 
+               if (return_flag)       return                          ! return for a non-zero error code
+               
+               call save_recover                                      ! save/recover copies of variables and fluxes
+
+               call get_split_indices; if (return_flag) return        ! get indices for a given split - return for a non-zero error code
+               call update_fluxMask;   if (return_flag) return        ! define the mask for the fluxes used - return for a non-zero error code
+               !! end create split
+
+               !! solve subset
+               call solve_subset;      if (return_flag) return        ! solve variable subset for one time step - return for a positive error code
+               !! end solve subset
+
+               !! validate solution
+               call assess_solution;   if (return_flag) return        ! is solution a success or failure? - return for a recovering solution
+
+               call try_other_solution_methods                        ! if solution failed to converge, try other splitting methods 
+               if (cycle_coupling)        cycle split_select_loop     ! if needed, proceed to next iteration of coupling method
+               if (cycle_stateThenDomain) cycle split_select_loop     ! if needed, proceed to next iteration of stateThenDomain method
+               if (cycle_solution)        cycle split_select_loop     ! if needed, proceed to next iteration of solution method 
+
+               call confirm_variable_updates; if (return_flag) return ! check that state variables are updated - return if error 
+
+               call success_check                                     ! check for success
+               call check_exit_stateThenDomain                        ! check exit criterion for stateThenDomain split
+               call check_exit_solution; if (return_flag) return      ! check exit criterion for solution split - return if error 
+               !! end validate solution
+             end if ! stateSplit ends
+             call finalize_split_stateSplit
+           end if ! solution ends
+           call finalize_split_solution
+         end if ! domainSplit ends
+         call finalize_split_domainSplit
+       end if ! stateThenDomain ends
+       call finalize_split_stateThenDomain; if (return_flag) return
+     end if ! stateTypeSplitting ends
+     call finalize_split_stateTypeSplitting; if (exit_split_select) exit split_select_loop; if (return_flag) return
+   end do split_select_loop ! coupling ends
+  end subroutine update_opSplittin
+
+  subroutine finalize_opSplittin
+   ! *** Final operations for opSplittin ***
+   call finalize_split_coupling; if (return_flag) return
+  end subroutine finalize_opSplittin
 
   subroutine initialize_split_select
    ! *** Initialize split_select class object ***

--- a/build/source/engine/opSplittin.f90
+++ b/build/source/engine/opSplittin.f90
@@ -371,7 +371,7 @@ subroutine opSplittin(&
            if (split_select % solution) then     ! solution begins
              call initialize_split_stateSplit; if (return_flag) return 
              if (split_select % stateSplit) then ! stateSplit begins
-               !! create split
+               !! create split -- call initialize_split
                call update_stateMask; if (return_flag) return         ! get the mask for the state subset - return for a non-zero error code
                call validate_split                                    ! verify that the split is valid
                if (cycle_domainSplit) cycle split_select_loop         ! if needed, proceed to next iteration of domainSplit method 
@@ -384,23 +384,27 @@ subroutine opSplittin(&
                call update_fluxMask;   if (return_flag) return        ! define the mask for the fluxes used - return for a non-zero error code
                !! end create split
 
-               !! solve subset
-               call solve_subset;      if (return_flag) return        ! solve variable subset for one time step - return for a positive error code
+               !! solve subset -- call update_split -- draft done
+               call update_split;   if (return_flag) return
+               !call solve_subset;      if (return_flag) return        ! solve variable subset for one time step - return for a positive error code
                !! end solve subset
 
-               !! validate solution
-               call assess_solution;   if (return_flag) return        ! is solution a success or failure? - return for a recovering solution
+               !! validate solution -- call finalize_split -- draft done
+               call finalize_split; if (return_flag) return
+               if (any([cycle_coupling,cycle_stateThenDomain,cycle_solution])) cycle split_select_loop ! if needed, proceed to next split
 
-               call try_other_solution_methods                        ! if solution failed to converge, try other splitting methods 
-               if (cycle_coupling)        cycle split_select_loop     ! if needed, proceed to next iteration of coupling method
-               if (cycle_stateThenDomain) cycle split_select_loop     ! if needed, proceed to next iteration of stateThenDomain method
-               if (cycle_solution)        cycle split_select_loop     ! if needed, proceed to next iteration of solution method 
+               !call assess_solution;   if (return_flag) return        ! is solution a success or failure? - return for a recovering solution
 
-               call confirm_variable_updates; if (return_flag) return ! check that state variables are updated - return if error 
+               !call try_other_solution_methods                        ! if solution failed to converge, try other splitting methods 
+               !if (cycle_coupling)        cycle split_select_loop     ! if needed, proceed to next iteration of coupling method
+               !if (cycle_stateThenDomain) cycle split_select_loop     ! if needed, proceed to next iteration of stateThenDomain method
+               !if (cycle_solution)        cycle split_select_loop     ! if needed, proceed to next iteration of solution method 
 
-               call success_check                                     ! check for success
-               call check_exit_stateThenDomain                        ! check exit criterion for stateThenDomain split
-               call check_exit_solution; if (return_flag) return      ! check exit criterion for solution split - return if error 
+               !call confirm_variable_updates; if (return_flag) return ! check that state variables are updated - return if error 
+
+               !call success_check                                     ! check for success
+               !call check_exit_stateThenDomain                        ! check exit criterion for stateThenDomain split
+               !call check_exit_solution; if (return_flag) return      ! check exit criterion for solution split - return if error 
                !! end validate solution
              end if ! stateSplit ends
              call finalize_split_stateSplit
@@ -419,6 +423,34 @@ subroutine opSplittin(&
    ! *** Final operations for opSplittin ***
    call finalize_split_coupling; if (return_flag) return
   end subroutine finalize_opSplittin
+
+  subroutine initialize_split
+   ! *** Initialize logical masks for selected splitting method ***
+  end subroutine initialize_split
+
+  subroutine update_split
+   ! *** Update solution for selected splitting method ***
+   call solve_subset; if (return_flag) return ! solve variable subset for one time step - return for a positive error code
+  end subroutine update_split
+
+  subroutine finalize_split
+   ! *** Finalize solution for selected splitting method ***
+   call assess_solution;   if (return_flag) return        ! is solution a success or failure? - return for a recovering solution
+
+   call try_other_solution_methods                        ! if solution failed to converge, try other splitting methods 
+   if (cycle_coupling)        return                      ! if needed, proceed to next iteration of coupling method
+   if (cycle_stateThenDomain) return                      ! if needed, proceed to next iteration of stateThenDomain method
+   if (cycle_solution)        return                      ! if needed, proceed to next iteration of solution method 
+   !if (cycle_coupling)        cycle split_select_loop     ! if needed, proceed to next iteration of coupling method
+   !if (cycle_stateThenDomain) cycle split_select_loop     ! if needed, proceed to next iteration of stateThenDomain method
+   !if (cycle_solution)        cycle split_select_loop     ! if needed, proceed to next iteration of solution method 
+
+   call confirm_variable_updates; if (return_flag) return ! check that state variables are updated - return if error 
+
+   call success_check                                     ! check for success
+   call check_exit_stateThenDomain                        ! check exit criterion for stateThenDomain split
+   call check_exit_solution;      if (return_flag) return ! check exit criterion for solution split - return if error 
+  end subroutine finalize_split
 
   subroutine initialize_split_select
    ! *** Initialize split_select class object ***


### PR DESCRIPTION
Hey @ashleymedin !

This PR includes refactoring updates for summa_driver.f90 and opSplittin.f90 to help address comments raised for the SUMMA-ROO draft. The summa_driver program has been updated to use initialize (memory allocation), update (time step loop), and finalize (error control, stopping) subroutines. The opSplittin module subroutine was also restructured into initialize, update, and finalize internal subroutines. This gives a much simpler overview of opSplittin instead of just jumping into the operator splitting loop (which has also been modularized for simplicity and conciseness). Several unused variables imported into opSplittin_module were removed.

Minor cosmetic and comment updates were also applied for smoother reading. All updates were successfully tested using the full test suite with the gcc-12 compiler family for the build. Code output and resource usage were not impacted.

As previously mentioned, there is an open issue with gcc-13+ related to allocatable data components of derived types that can lead to unexpected segmentation faults in some cases. A potential solution is in progress, which would allow confident usage of SUMMA with gcc-13+. If all goes well, I will submit a separate PR for the fix in the coming days.  

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] Closes #xxx (identify the issue associated with this PR)
- [x] Code passes standard test cases (results are either bit-for-bit identical, or differences are explained in the PR comment)
- [ ] New tests added (describe which tests were performed to test the changes)
- [ ] Science test figures (add figures to PR comment and describe the tests)
- [ ] Checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] Describe the change in the release notes (use  `./summa/docs/whats-new.md`)