### PR TITLE
Simplifying the object-oriented methods used for stateFilter

### DIFF
--- a/build/source/dshare/data_types.f90
+++ b/build/source/dshare/data_types.f90
@@ -591,7 +591,6 @@ MODULE data_types
  end type in_type_stateFilter
 
  type, public :: out_type_stateFilter ! class for intent(out) arguments in stateFilter call
-   integer(i4b)             :: nSubset                     ! intent(out): number of selected state variables for a given split
    integer(i4b)             :: err                         ! intent(out): error code
    character(len=len_msg)   :: cmessage                    ! intent(out): error message
   contains
@@ -1391,12 +1390,10 @@ contains
   in_stateFilter % iStateSplit       = iStateSplit            ! intent(in): index of the layer split
  end subroutine initialize_in_stateFilter
 
- subroutine finalize_out_stateFilter(out_stateFilter,nSubset,err,cmessage)
+ subroutine finalize_out_stateFilter(out_stateFilter,err,cmessage)
   class(out_type_stateFilter),intent(in) :: out_stateFilter   ! class object for intent(out) stateFilter arguments
-  integer(i4b),intent(out)               :: nSubset           ! intent(out): number of selected state variables for a given split
   integer(i4b),intent(out)               :: err               ! intent(out): error code
   character(*),intent(out)               :: cmessage          ! intent(out): error message
-  nSubset  = out_stateFilter % nSubset                        ! intent(out): number of selected state variables for a given split 
   err      = out_stateFilter % err                            ! intent(out): error code
   cmessage = out_stateFilter % cmessage                       ! intent(out): error message
  end subroutine finalize_out_stateFilter

--- a/build/source/dshare/data_types.f90
+++ b/build/source/dshare/data_types.f90
@@ -579,17 +579,6 @@ MODULE data_types
  ! Define classes used to simplify calls to the subrotuines in opSplittin
  ! ***********************************************************************************************************
  ! ** stateFilter
- type, public :: in_type_stateFilter  ! class for intent(in) arguments in stateFilter call
-   integer(i4b)             :: ixCoupling                  ! intent(in): index of coupling method (1,2)
-   integer(i4b)             :: ixSolution                  ! intent(in): index of solution method (1,2)
-   integer(i4b)             :: ixStateThenDomain           ! intent(in): switch between full domain and sub domains
-   integer(i4b)             :: iStateTypeSplit             ! intent(in): index of the state type split
-   integer(i4b)             :: iDomainSplit                ! intent(in): index of the domain split
-   integer(i4b)             :: iStateSplit                 ! intent(in): index of the layer split
-  contains
-   procedure :: initialize => initialize_in_stateFilter
- end type in_type_stateFilter
-
  type, public :: out_type_stateFilter ! class for intent(out) arguments in stateFilter call
    integer(i4b)             :: err                         ! intent(out): error code
    character(len=len_msg)   :: cmessage                    ! intent(out): error message
@@ -1374,22 +1363,6 @@ contains
  ! **** end bigAquifer ****
 
  ! **** stateFilter ****
- subroutine initialize_in_stateFilter(in_stateFilter,ixCoupling,ixSolution,ixStateThenDomain,iStateTypeSplit,iDomainSplit,iStateSplit)
-  class(in_type_stateFilter),intent(out) :: in_stateFilter    ! class object for intent(in) stateFilter arguments
-  integer(i4b),intent(in)                :: ixCoupling        ! intent(in): index of coupling method (1,2)
-  integer(i4b),intent(in)                :: ixSolution        ! intent(in): index of solution method (1,2)
-  integer(i4b),intent(in)                :: ixStateThenDomain ! intent(in): switch between full domain and sub domains
-  integer(i4b),intent(in)                :: iStateTypeSplit   ! intent(in): index of the state type split
-  integer(i4b),intent(in)                :: iDomainSplit      ! intent(in): index of the domain split
-  integer(i4b),intent(in)                :: iStateSplit       ! intent(in): index of the layer split
-  in_stateFilter % ixCoupling        = ixCoupling             ! intent(in): index of coupling method (1,2)
-  in_stateFilter % ixSolution        = ixSolution             ! intent(in): index of solution method (1,2)
-  in_stateFilter % ixStateThenDomain = ixStateThenDomain      ! intent(in): switch between full domain and sub domains
-  in_stateFilter % iStateTypeSplit   = iStateTypeSplit        ! intent(in): index of the state type split
-  in_stateFilter % iDomainSplit      = iDomainSplit           ! intent(in): index of the domain split
-  in_stateFilter % iStateSplit       = iStateSplit            ! intent(in): index of the layer split
- end subroutine initialize_in_stateFilter
-
  subroutine finalize_out_stateFilter(out_stateFilter,err,cmessage)
   class(out_type_stateFilter),intent(in) :: out_stateFilter   ! class object for intent(out) stateFilter arguments
   integer(i4b),intent(out)               :: err               ! intent(out): error code

--- a/build/source/engine/opSplittin.f90
+++ b/build/source/engine/opSplittin.f90
@@ -1447,9 +1447,7 @@ subroutine split_select_compute_stateMask(split_select,indx_data,err,cmessage,me
   call in_stateFilter % initialize(ixCoupling,ixSolution,ixStateThenDomain,iStateTypeSplit,iDomainSplit,iStateSplit)
  end associate
  call stateFilter(in_stateFilter,indx_data,split_select,out_stateFilter)
- associate(nSubset => split_select % nSubset)
-  call out_stateFilter % finalize(nSubset,err,cmessage)
- end associate
+ call out_stateFilter % finalize(err,cmessage)
  if (err/=0) then; message=trim(message)//trim(cmessage); return_flag=.true.; return; end if  ! error control
 end subroutine split_select_compute_stateMask
 
@@ -1499,9 +1497,7 @@ end subroutine split_select_compute_stateMask
  call identify_scalar_solutions; if (return_flag) return ! identify scalar solutions -- return if error occurs
 
  ! get the number of selected state variables
- associate(nSubset => out_stateFilter % nSubset) ! intent(out): number of selected state variables for a given split
-  nSubset = count(split_select % stateMask)
- end associate
+ split_select % nSubset = count(split_select % stateMask)
 
 contains
 

--- a/build/source/engine/opSplittin.f90
+++ b/build/source/engine/opSplittin.f90
@@ -69,7 +69,7 @@ USE data_types,only:&
                     var_dlength,                                               & ! data vector with variable length dimension (rkind)
                     zLookup,                                                   & ! lookup tables
                     model_options,                                             & ! defines the model decisions
-                    in_type_statefilter,out_type_statefilter,                  & ! classes for stateFilter objects
+                    out_type_stateFilter,                                      & ! classes for stateFilter objects
                     in_type_indexSplit,out_type_indexSplit,                    & ! classes for indexSplit objects
                     in_type_varSubstep,io_type_varSubstep,out_type_varSubstep    ! classes for varSubstep objects
 
@@ -1432,21 +1432,11 @@ subroutine split_select_compute_stateMask(split_select,indx_data,err,cmessage,me
  character(*),intent(out)               :: message                   ! error message
  logical(lgt),intent(out)               :: return_flag               ! return flag
  ! local variables
- type(in_type_stateFilter)              :: in_stateFilter            ! indices
  type(out_type_stateFilter)             :: out_stateFilter           ! number of selected state variables for a given split and error control
 
  err=0               ! initialize error code 
  return_flag=.false. ! initialize flag
- associate(&
-  ixCoupling        => split_select % ixCoupling        ,& 
-  ixSolution        => split_select % ixSolution        ,&
-  ixStateThenDomain => split_select % ixStateThenDomain ,&
-  iStateTypeSplit   => split_select % iStateTypeSplit   ,&
-  iDomainSplit      => split_select % iDomainSplit      ,&
-  iStateSplit       => split_select % iStateSplit        )
-  call in_stateFilter % initialize(ixCoupling,ixSolution,ixStateThenDomain,iStateTypeSplit,iDomainSplit,iStateSplit)
- end associate
- call stateFilter(in_stateFilter,indx_data,split_select,out_stateFilter)
+ call stateFilter(indx_data,split_select,out_stateFilter)
  call out_stateFilter % finalize(err,cmessage)
  if (err/=0) then; message=trim(message)//trim(cmessage); return_flag=.true.; return; end if  ! error control
 end subroutine split_select_compute_stateMask
@@ -1455,11 +1445,10 @@ end subroutine split_select_compute_stateMask
 ! **********************************************************************************************************
 ! private subroutine stateFilter: get a mask for the desired state variables
 ! **********************************************************************************************************
- subroutine stateFilter(in_stateFilter,indx_data,split_select,out_stateFilter)
+ subroutine stateFilter(indx_data,split_select,out_stateFilter)
  USE indexState_module,only:indxSubset                               ! get state indices
  implicit none
  ! input
- type(in_type_stateFilter),intent(in)   :: in_stateFilter            ! indices
  type(var_ilength),intent(in)           :: indx_data                 ! indices for a local HRU
  ! input-output
  type(split_select_type),intent(inout)  :: split_select              ! class object for operator splitting selector
@@ -1471,7 +1460,7 @@ end subroutine split_select_compute_stateMask
  logical(lgt)                           :: return_flag               ! flag to indicate a return 
  ! ----------------------------------------------------------------------------------------------------------------------------------------------------
  ! data structures
- associate(ixCoupling => in_stateFilter % ixCoupling,&  ! intent(in): [i4b] index of coupling method (1,2)
+ associate(ixCoupling => split_select % ixCoupling  ,&  ! intent(in): [i4b] index of coupling method (1,2)
            err        => out_stateFilter % err      ,&  ! intent(out): error code
            message    => out_stateFilter % cmessage  )  ! intent(out): error message
    
@@ -1511,9 +1500,9 @@ contains
   return_flag=.false. ! initialize flag
   ! switch between full domain and sub domains
   associate(&
-   ixStateThenDomain => in_stateFilter % ixStateThenDomain ,& ! intent(in): [i4b] switch between full domain and sub domains
-   err               => out_stateFilter % err              ,& ! intent(out): error code
-   message           => out_stateFilter % cmessage          ) ! intent(out): error message
+   ixStateThenDomain => split_select % ixStateThenDomain,& ! intent(in): [i4b] switch between full domain and sub domains
+   err               => out_stateFilter % err           ,& ! intent(out): error code
+   message           => out_stateFilter % cmessage       ) ! intent(out): error message
    select case(ixStateThenDomain)
      ! split into energy and mass
      case(fullDomain); call stateTypeSplit_fullDomain_stateMask; if (return_flag) return
@@ -1529,9 +1518,9 @@ contains
  subroutine stateTypeSplit_fullDomain_stateMask
   ! *** Get full domain stateMask ***
   return_flag=.false. ! initialize flag
-  associate(iStateTypeSplit => in_stateFilter % iStateTypeSplit          ,& ! intent(in): [i4b] index of the state type split
-            err             => out_stateFilter % err                     ,& ! intent(out): error code
-            message         => out_stateFilter % cmessage                 ) ! intent(out): error message
+  associate(iStateTypeSplit => split_select % iStateTypeSplit,& ! intent(in): [i4b] index of the state type split
+            err             => out_stateFilter % err         ,& ! intent(out): error code
+            message         => out_stateFilter % cmessage     ) ! intent(out): error message
    select case(iStateTypeSplit)
     case(nrgSplit);  call stateTypeSplit_fullDomain_nrgSplit_stateMask
     case(massSplit); call stateTypeSplit_fullDomain_massSplit_stateMask
@@ -1560,9 +1549,9 @@ contains
   return_flag=.false. ! initialize flag
   ! define state mask
   associate(&
-            iStateTypeSplit => in_stateFilter % iStateTypeSplit          ,& ! intent(in): [i4b] index of the state type split
-            err             => out_stateFilter % err                     ,& ! intent(out): error code
-            message         => out_stateFilter % cmessage                 ) ! intent(out): error message
+            iStateTypeSplit => split_select % iStateTypeSplit,& ! intent(in): [i4b] index of the state type split
+            err             => out_stateFilter % err         ,& ! intent(out): error code
+            message         => out_stateFilter % cmessage     ) ! intent(out): error message
    split_select % stateMask(:)=.false. ! initialize state mask
    select case(iStateTypeSplit)
     ! define mask for energy
@@ -1579,9 +1568,9 @@ contains
   ! *** Get subdomain energy split stateMask ***
   return_flag=.false. ! initialize flag
   associate(&
-   iDomainSplit    => in_stateFilter % iDomainSplit             ,& ! intent(in): [i4b] index of the domain split
-   err             => out_stateFilter % err                     ,& ! intent(out): error code
-   message         => out_stateFilter % cmessage                 ) ! intent(out): error message
+   iDomainSplit    => split_select % iDomainSplit,& ! intent(in): [i4b] index of the domain split
+   err             => out_stateFilter % err      ,& ! intent(out): error code
+   message         => out_stateFilter % cmessage  ) ! intent(out): error message
    select case(iDomainSplit)
     case(vegSplit);  call stateTypeSplit_subDomain_nrgSplit_vegSplit_stateMask       ! vegetation subdomain
     case(snowSplit); call stateTypeSplit_subDomain_nrgSplit_snowSplit_stateMask      ! snow subdomain
@@ -1595,9 +1584,9 @@ contains
  subroutine stateTypeSplit_subDomain_nrgSplit_vegSplit_stateMask
   ! *** Get state type subdomain energy vegetation split ***
   associate(&
-   ixNrgCanair     => indx_data%var(iLookINDEX%ixNrgCanair)%dat ,& ! intent(in): [i4b(:)] indices IN THE FULL VECTOR for energy states in canopy air space domain
-   ixNrgCanopy     => indx_data%var(iLookINDEX%ixNrgCanopy)%dat ,& ! intent(in): [i4b(:)] indices IN THE FULL VECTOR for energy states in the canopy domain
-   ixNrgLayer      => indx_data%var(iLookINDEX%ixNrgLayer)%dat   ) ! intent(in): [i4b(:)] indices IN THE FULL VECTOR for energy states in the snow+soil domain
+   ixNrgCanair => indx_data%var(iLookINDEX%ixNrgCanair)%dat,& ! intent(in): [i4b(:)] indices IN THE FULL VECTOR for energy states in canopy air space domain
+   ixNrgCanopy => indx_data%var(iLookINDEX%ixNrgCanopy)%dat,& ! intent(in): [i4b(:)] indices IN THE FULL VECTOR for energy states in the canopy domain
+   ixNrgLayer  => indx_data%var(iLookINDEX%ixNrgLayer)%dat  ) ! intent(in): [i4b(:)] indices IN THE FULL VECTOR for energy states in the snow+soil domain
      if (ixNrgCanair(1)/=integerMissing) split_select % stateMask(ixNrgCanair) = .true.  ! energy of the canopy air space
      if (ixNrgCanopy(1)/=integerMissing) split_select % stateMask(ixNrgCanopy) = .true.  ! energy of the vegetation canopy
      split_select % stateMask(ixNrgLayer(1)) = .true.  ! energy of the upper-most layer in the snow+soil domain
@@ -1606,8 +1595,8 @@ contains
 
  subroutine stateTypeSplit_subDomain_nrgSplit_snowSplit_stateMask
   associate(&
-   nSnow           => indx_data%var(iLookINDEX%nSnow)%dat(1)    ,& ! intent(in): [i4b] number of snow layers
-   ixNrgLayer      => indx_data%var(iLookINDEX%ixNrgLayer)%dat   ) ! intent(in): [i4b(:)] indices IN THE FULL VECTOR for energy states in the snow+soil domain
+   nSnow      => indx_data%var(iLookINDEX%nSnow)%dat(1)  ,& ! intent(in): [i4b] number of snow layers
+   ixNrgLayer => indx_data%var(iLookINDEX%ixNrgLayer)%dat ) ! intent(in): [i4b(:)] indices IN THE FULL VECTOR for energy states in the snow+soil domain
   ! *** Get state type subdomain energy snow split ***
    if (nSnow>1) split_select % stateMask(ixNrgLayer(2:nSnow)) = .true. ! NOTE: (2:) because the top layer in the snow+soil domain included in vegSplit
   end associate
@@ -1616,9 +1605,9 @@ contains
  subroutine stateTypeSplit_subDomain_nrgSplit_soilSplit_stateMask
   ! *** Get state type subdomain energy soil split ***
   associate(&
-   nSnow           => indx_data%var(iLookINDEX%nSnow)%dat(1)    ,& ! intent(in): [i4b] number of snow layers
-   nLayers         => indx_data%var(iLookINDEX%nLayers)%dat(1)  ,& ! intent(in): [i4b] total number of layers
-   ixNrgLayer      => indx_data%var(iLookINDEX%ixNrgLayer)%dat   ) ! intent(in): [i4b(:)] indices IN THE FULL VECTOR for energy states in the snow+soil domain
+   nSnow      => indx_data%var(iLookINDEX%nSnow)%dat(1)  ,& ! intent(in): [i4b] number of snow layers
+   nLayers    => indx_data%var(iLookINDEX%nLayers)%dat(1),& ! intent(in): [i4b] total number of layers
+   ixNrgLayer => indx_data%var(iLookINDEX%ixNrgLayer)%dat ) ! intent(in): [i4b(:)] indices IN THE FULL VECTOR for energy states in the snow+soil domain
    split_select % stateMask(ixNrgLayer(max(2,nSnow+1):nLayers)) = .true. ! NOTE: max(2,nSnow+1) gives second layer unless more than 2 snow layers
   end associate
  end subroutine stateTypeSplit_subDomain_nrgSplit_soilSplit_stateMask
@@ -1627,9 +1616,9 @@ contains
   ! *** Get subdomain mass split stateMask ***
   return_flag=.false. ! initialize flag
   associate(&
-   iDomainSplit    => in_stateFilter % iDomainSplit             ,& ! intent(in): [i4b] index of the domain split
-   err             => out_stateFilter % err                     ,& ! intent(out): error code
-   message         => out_stateFilter % cmessage                 ) ! intent(out): error message
+   iDomainSplit => split_select % iDomainSplit,& ! intent(in): [i4b] index of the domain split
+   err          => out_stateFilter % err      ,& ! intent(out): error code
+   message      => out_stateFilter % cmessage  ) ! intent(out): error message
    select case(iDomainSplit)
     case(vegSplit);     call stateTypeSplit_subDomain_massSplit_vegSplit_stateMask     ! vegetation subdomain
     case(snowSplit);    call stateTypeSplit_subDomain_massSplit_snowSplit_stateMask    ! snow subdomain
@@ -1650,8 +1639,8 @@ contains
  subroutine stateTypeSplit_subDomain_massSplit_snowSplit_stateMask
   ! *** Get mass state snow subdomain split stateMask  ***
   associate(&
-   nSnow           => indx_data%var(iLookINDEX%nSnow)%dat(1)    ,& ! intent(in): [i4b] number of snow layers
-   ixHydLayer      => indx_data%var(iLookINDEX%ixHydLayer)%dat   ) ! intent(in): [i4b(:)] indices IN THE FULL VECTOR for hydrology states in the snow+soil domain
+   nSnow      => indx_data%var(iLookINDEX%nSnow)%dat(1)  ,& ! intent(in): [i4b] number of snow layers
+   ixHydLayer => indx_data%var(iLookINDEX%ixHydLayer)%dat ) ! intent(in): [i4b(:)] indices IN THE FULL VECTOR for hydrology states in the snow+soil domain
    split_select % stateMask(ixHydLayer(1:nSnow)) = .true.  ! snow hydrology
   end associate
  end subroutine stateTypeSplit_subDomain_massSplit_snowSplit_stateMask
@@ -1659,9 +1648,9 @@ contains
  subroutine stateTypeSplit_subDomain_massSplit_soilSplit_stateMask
   ! *** Get mass state soil subdomain split stateMask  ***
   associate(&
-   nSnow           => indx_data%var(iLookINDEX%nSnow)%dat(1)    ,& ! intent(in): [i4b] number of snow layers
-   nLayers         => indx_data%var(iLookINDEX%nLayers)%dat(1)  ,& ! intent(in): [i4b] total number of layers
-   ixHydLayer      => indx_data%var(iLookINDEX%ixHydLayer)%dat   ) ! intent(in): [i4b(:)] indices IN THE FULL VECTOR for hydrology states in the snow+soil domain
+   nSnow      => indx_data%var(iLookINDEX%nSnow)%dat(1)  ,& ! intent(in): [i4b] number of snow layers
+   nLayers    => indx_data%var(iLookINDEX%nLayers)%dat(1),& ! intent(in): [i4b] total number of layers
+   ixHydLayer => indx_data%var(iLookINDEX%ixHydLayer)%dat ) ! intent(in): [i4b(:)] indices IN THE FULL VECTOR for hydrology states in the snow+soil domain
    split_select % stateMask(ixHydLayer(nSnow+1:nLayers)) = .true.  ! soil hydrology
   end associate
  end subroutine stateTypeSplit_subDomain_massSplit_soilSplit_stateMask
@@ -1676,11 +1665,11 @@ contains
  subroutine identify_scalar_solutions
   ! *** Identify scalar solutions ***
   return_flag=.false. ! initialize flag
-  associate(ixAllState  => indx_data%var(iLookINDEX%ixAllState)%dat ,& ! intent(in): [i4b(:)] list of indices for all model state variables (1,2,3,...nState)
-            ixSolution  => in_stateFilter % ixSolution              ,& ! intent(in): [i4b] index of solution method (1,2)
-            iStateSplit => in_stateFilter % iStateSplit             ,& ! intent(in): [i4b] index of the layer split
-            err         => out_stateFilter % err                    ,& ! intent(out): error code
-            message     => out_stateFilter % cmessage                ) ! intent(out): error message
+  associate(ixAllState  => indx_data%var(iLookINDEX%ixAllState)%dat,& ! intent(in): [i4b(:)] list of indices for all model state variables (1,2,3,...nState)
+            ixSolution  => split_select % ixSolution               ,& ! intent(in): [i4b] index of solution method (1,2)
+            iStateSplit => split_select % iStateSplit              ,& ! intent(in): [i4b] index of the layer split
+            err         => out_stateFilter % err                   ,& ! intent(out): error code
+            message     => out_stateFilter % cmessage               ) ! intent(out): error message
    if (ixSolution==scalar) then
     ! get the subset of indices
     call indxSubset(ixSubset, ixAllState, split_select % stateMask, err, cmessage)


### PR DESCRIPTION
Hi @ashleymedin !

This PR simplifies the use of objects in stateFilter. A previous PR introduced the split_select object as an argument for stateFilter (to alleviate segmentation errors). However, the inclusion of split_select made some existing object-oriented operations redundant in stateFillter. In particular, the data contained in the in_stateFilter object is already contained in split_select. Accordingly, the in_stateFilter object and corresponding in_type_stateFilter class were removed. References to in_stateFilter have been replaced with references to split_select where needed. Also, the nSubset data component of the out_stateFilter object is already contained in split_select. Thus, that component was removed from the out_type_stateFilter class, and is now handled with the split_select object.

These updates have reduced the number of data transfer operations needed, and have been successfully tested using the SUMMA test suite (using gcc-14). Changes were structural in nature and do not impact code output. 

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] Closes #xxx (identify the issue associated with this PR)
- [x] Code passes standard test cases (results are either bit-for-bit identical, or differences are explained in the PR comment)
- [ ] New tests added (describe which tests were performed to test the changes)
- [ ] Science test figures (add figures to PR comment and describe the tests)
- [ ] Checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] Describe the change in the release notes (use  `./summa/docs/whats-new.md`)