### PR TITLE
Refactoring updates for summaSolve4homegrown

### DIFF
--- a/build/source/engine/summaSolve4homegrown.f90
+++ b/build/source/engine/summaSolve4homegrown.f90
@@ -215,17 +215,12 @@ contains
 
  ! ***** Compute the Newton Step *****
 
- call initialize_summaSolve4homegrown; if (return_flag) return ! initial setup -- return if error
-
- call update_Jacobian;                 if (return_flag) return ! compute Jacobian for Newton step -- return if error
-
- call solve_linear_system;             if (return_flag) return ! solve the linear system for the Newton step -- return if error
-
- call refine_Newton_step;              if (return_flag) return ! refine Newton step if needed -- return if error
-
- associate(err => out_SS4HG % err,message   => out_SS4HG % message)
-  if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
- end associate
+ ! initial setup including computing the Jacobian -- return if error
+ call initialize_summaSolve4homegrown; if (return_flag) return 
+ ! compute the Newton step -- return if error
+ call update_summaSolve4homegrown;     if (return_flag) return 
+ ! final check for errors
+ call finalize_summaSolve4homegrown;   if (return_flag) return
 
  contains
 
@@ -258,7 +253,24 @@ contains
   
    ! initialize the global print flag
    globalPrintFlagInit=globalPrintFlag
+
+   ! compute the Jacobian
+   call update_Jacobian; if (return_flag) return ! compute Jacobian for Newton step -- return if error
   end subroutine initialize_summaSolve4homegrown
+
+  subroutine update_summaSolve4homegrown
+   ! *** Update steps for the summaSolve4homegrown algorithm (computing the Newton step) ***
+   call solve_linear_system;             if (return_flag) return ! solve the linear system for the Newton step -- return if error
+  
+   call refine_Newton_step;              if (return_flag) return ! refine Newton step if needed -- return if error
+  end subroutine update_summaSolve4homegrown
+
+  subroutine finalize_summaSolve4homegrown
+   ! *** Final steps for the summaSolve4homegrown algorithm (computing the Newton step) ***
+   associate(err => out_SS4HG % err,message => out_SS4HG % message)
+    if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
+   end associate
+  end subroutine finalize_summaSolve4homegrown
 
   subroutine update_Jacobian
    ! *** Update Jacobian used for Newton step ***


### PR DESCRIPTION
Hi @ashleymedin - This PR applies the initialize-update-finalize modularization strategy to the summaSolve4homegrown subroutine. This involved moving the Jacobian update step into the initialize_summaSolve4homegrown internal subroutine. The update_summaSolve4homegrown and finalize_summaSolve4homegrown internal subroutines were created, which house operations for computing/refining the Newton step and error control, respectively.

This PR is structural in nature and does not impact code output or resource use. This was tested with the full test suite.

Hopefully, this does not create difficulties for your work on glaciers. This update was done to apply improvements similar to what Martyn suggested. I'll admit that is does look simpler in the GMD draft.

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] Closes #xxx (identify the issue associated with this PR)
- [x] Code passes standard test cases (results are either bit-for-bit identical, or differences are explained in the PR comment)
- [ ] New tests added (describe which tests were performed to test the changes)
- [ ] Science test figures (add figures to PR comment and describe the tests)
- [ ] Checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] Describe the change in the release notes (use  `./summa/docs/whats-new.md`)