### PR TITLE
Updated surface runoff partitioning for liquid flux surface hydrology boundary condition

### DIFF
--- a/build/source/engine/soilLiqFlx.f90
+++ b/build/source/engine/soilLiqFlx.f90
@@ -1882,6 +1882,10 @@ contains
 
  subroutine update_surfaceFlx_liquidFlux_infiltration
   ! **** Update operations for surfaceFlx: flux condition -- final infiltration and runoff calculations ****
+  ! local variables
+  real(rkind) :: scalarInfilArea_unfrozen ! infiltration area that is not frozen
+
+  ! compute infiltration and runoff
   associate(&
    ! input: flux at the upper boundary
    scalarRainPlusMelt => in_surfaceFlx % scalarRainPlusMelt , & ! rain plus melt, used as input to the soil zone before computing surface runoff (m s-1)
@@ -1899,13 +1903,23 @@ contains
    scalarSurfaceRunoff_SE    => out_surfaceFlx % scalarSurfaceRunoff_SE    , & ! saturation excess surface runoff (m s-1)
    scalarSurfaceInfiltration => out_surfaceFlx % scalarSurfaceInfiltration   & ! surface infiltration (m s-1)
   &)
+   ! unfrozen infiltration area
+   scalarInfilArea_unfrozen=(1._rkind - scalarFrozenArea)*scalarInfilArea
+
    ! compute infiltration (m s-1), if after first flux call in a splitting operation does not change
-   scalarSurfaceInfiltration = (1._rkind - scalarFrozenArea)*scalarInfilArea*min(scalarRainPlusMelt,xMaxInfilRate)
+   scalarSurfaceInfiltration = scalarInfilArea_unfrozen*min(scalarRainPlusMelt,xMaxInfilRate)
  
    ! compute surface runoff (m s-1)
    scalarSurfaceRunoff    = scalarRainPlusMelt - scalarSurfaceInfiltration
-   scalarSurfaceRunoff_IE = scalarSurfaceRunoff ! infiltration excess runoff 
-   scalarSurfaceRunoff_SE = 0._rkind            ! saturation excess runoff 
+   if (scalarRainPlusMelt.gt.xMaxInfilRate) then ! infiltration excess runoff occurs
+    ! saturation excess runoff
+    scalarSurfaceRunoff_SE = scalarRainPlusMelt * (1._rkind - scalarInfilArea_unfrozen) ! (rain plus melt) * (saturated area) 
+    ! remaining runoff is infiltration excess
+    scalarSurfaceRunoff_IE = scalarSurfaceRunoff - scalarSurfaceRunoff_SE ! infiltration excess runoff     
+   else ! infiltration excess runoff does not occur
+    scalarSurfaceRunoff_SE = scalarSurfaceRunoff ! saturation excess runoff 
+    scalarSurfaceRunoff_IE = 0._rkind            ! infiltration excess runoff 
+   end if
  
    ! set surface hydraulic conductivity and diffusivity to missing (not used for flux condition)
    surfaceHydCond = realMissing


### PR DESCRIPTION
Hi @ashleymedin - This PR updates the division between infiltration excess and saturation excess surface runoff for the liquid flux surface hydrology boundary condition. This update aims to address comments from @wknoben on the subdivision of surface runoff into both infiltration excess and saturation excess components. In general, non-zero contributions from both runoff types are possible simultaneously.

This update has been tested using the SUMMA test suite (expanded with FUSE and aquifer test cases). The only output differences detected were in the `scalarSurfaceRunoff_IE` and `scalarSurfaceRunoff_IE` variables. These output differences are consistent with the surface runoff partitioning updates from this PR.

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] Closes #xxx (identify the issue associated with this PR)
- [x] Code passes standard test cases (results are either bit-for-bit identical, or differences are explained in the PR comment)
- [ ] New tests added (describe which tests were performed to test the changes)
- [ ] Science test figures (add figures to PR comment and describe the tests)
- [ ] Checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] Describe the change in the release notes (use  `./summa/docs/whats-new.md`)