### PR TITLE
Handling negative base values in FUSE ARNO/VIC

### DIFF
--- a/build/source/engine/soilLiqFlx.f90
+++ b/build/source/engine/soilLiqFlx.f90
@@ -1325,8 +1325,8 @@ contains
   use soil_utils_module,only:SoftArgMax ! smooth arg max/min (for derivatives of LogSumExp)
 
   ! local variables
-  logical(lgt),parameter :: smoother = .false.                ! control for optional smoothing in base variable  
-  real(rkind) ,parameter :: alpha_LSE=1.e3_rkind              ! smoothness parameter for LSE smoother function
+  logical(lgt),parameter :: smoother = .true.                 ! control for optional smoothing in base variable  
+  real(rkind) ,parameter :: alpha_LSE= 1.e3_rkind             ! smoothness parameter for LSE smoother function
   real(rkind)            :: b                                 ! ARNO/VIC exponent (-) 
   real(rkind)            :: S1                                ! total water content in upper FUSE layer (m)
   real(rkind)            :: dS1_dWat(1:in_surfaceFlx % nSoil) ! derivative of S1 w.r.t. water content

--- a/build/source/engine/soil_utils.f90
+++ b/build/source/engine/soil_utils.f90
@@ -817,7 +817,7 @@ end function gser_complex
 ! public function LogSumExp: LSE (or RealSoftMax) function used for smooth approximations of max or min functions
 ! ******************************************************************************************************************************
 function LogSumExp(alpha,x,err) result(LSE)
-  use, intrinsic :: ieee_arithmetic,only:ieee_value,ieee_quiet_nan
+  use, intrinsic :: ieee_arithmetic,only:ieee_value,ieee_is_normal,ieee_quiet_nan
   use, intrinsic :: iso_fortran_env,only:real128
   implicit none
   ! input
@@ -850,6 +850,19 @@ function LogSumExp(alpha,x,err) result(LSE)
 
   LSE_qp= x_star + log(sum(exp(alpha_qp*(x_qp-x_star))))/alpha_qp
   LSE=real(LSE_qp,rkind)
+  
+  ! check if value is normal (not NaN, -Infinity, or +Infinity)
+  ! note: mainly to account for overflow/underflow that may occur in extreme cases
+  if (ieee_is_normal(LSE)) then ! return if value is not NaN or infinity
+    return
+  else                          ! revert to analytic max/min function as a failsafe (accurate but not smoothed)
+    if (alpha < 0._rkind) then  ! min
+      LSE = minval(x)
+    else                        ! max (alpha cannot be zero)
+      LSE = maxval(x)
+    end if
+  end if
+
 end function LogSumExp
 
 ! ******************************************************************************************************************************
@@ -858,6 +871,7 @@ end function LogSumExp
 ! Note: Can be used to evaluate the derivatives of LogSumExp
 ! dLogSumExp(alpha,x)_dx(i) = SoftArgMax(alpha,x)
 function SoftArgMax(alpha,x) result(SAM)
+  use, intrinsic :: ieee_arithmetic,only:ieee_is_normal
   use, intrinsic :: iso_fortran_env,only:real128
   implicit none
   ! input
@@ -880,6 +894,19 @@ function SoftArgMax(alpha,x) result(SAM)
 
   SAM_qp = exp(alpha_qp*(x_qp-x_star)) / sum(exp(alpha_qp*(x_qp-x_star)))
   SAM = real(SAM_qp,rkind)
+
+  ! check if all values are normal (not NaN, -Infinity, or +Infinity)
+  ! note: mainly to account for overflow/underflow that may occur in extreme cases
+  if (all(ieee_is_normal(SAM))) then ! return if value is not NaN or infinity
+    return
+  else                          ! revert to analytic arg max/min function in one-hot representation as a failsafe (accurate but not smoothed)
+    SAM(:) = 0._rkind
+    if (alpha < 0._rkind) then  ! arg min
+      SAM(minloc(x)) = 1._rkind
+    else                        ! arg max
+      SAM(maxloc(x)) = 1._rkind 
+    end if
+  end if
 end function
 
 end module soil_utils_module


### PR DESCRIPTION
Hi @ashleymedin - Thanks for your recent comments on Slack! Based on those comments, I propose this PR as a potential solution to handling possible negative base values for FUSE ARNO/VIC.

I have turned the optional smoothed minimum on to ensure that `S1_star` does not exceed the the theoretical maximum, which prevents negative `base` values in the saturated area formula.

I prefer using this method over setting the `base` value to zero because derivatives take the smoothed minimum into account. In other words, both the adjusted `base` value and the corresponding derivatives will be consistent. This consistency will remain even if a relatively large adjustment is needed (which may be important since we may not have a reliable error bound  for IDA). I suppose another way to think about it is we want to make sure the derivative values remain reasonable if we have to adjust `base`.

Also, I think having the smoother functions on for all solver choices is best for consistency (e.g., if we want to compare homegrown BE to IDA).

I also added some additional checks and safeguards to the smoother functions (`LogSumExp` and `SoftArgMax`). This was done to handle extreme cases of overflow and underflow that are unlikely to occur. However, as you said, we want to make things bomb-proof. Essentially, if all other checks and error prevention methods fail, 'LogSumExp' reverts to the analytic max/min function and `SoftArgMax` reverts to the analytic argmax/argmin function. So, even in the worst case scenario, the returned values will be accurate (just not smoothed). And in this worst case scenario, the ARNO/VIC `base` value will not go negative. 

In my FUSE test cases, turning the smoother on made no difference in compute time and output was nearly identical. The official test suite cases showed no changes in output or resource use.

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] Closes #xxx (identify the issue associated with this PR)
- [x] Code passes standard test cases (results are either bit-for-bit identical, or differences are explained in the PR comment)
- [ ] New tests added (describe which tests were performed to test the changes)
- [ ] Science test figures (add figures to PR comment and describe the tests)
- [ ] Checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] Describe the change in the release notes (use  `./summa/docs/whats-new.md`)