### PR TITLE
Updates to summaSolve4homegrown: made checkConv a module procedure for external access

### DIFF
--- a/build/source/engine/summaSolve4homegrown.f90
+++ b/build/source/engine/summaSolve4homegrown.f90
@@ -1126,7 +1126,7 @@ contains
   real(rkind),intent(in)       :: rVec(:)                      ! residual vector (mixed units)
   real(rkind),intent(in)       :: xInc(:)                      ! iteration increment (mixed units)
   real(rkind),intent(in)       :: xVec(:)                      ! state vector (mixed units)
-  type(out_type_summaSolve4homegrown),intent(out) :: out_SS4HG ! new function evaluation, convergence flag, and error control
+  type(out_type_summaSolve4homegrown),intent(in) :: out_SS4HG  ! new function evaluation, convergence flag, and error control
   ! locals
   real(rkind),dimension(mSoil) :: psiScale                ! scaling factor for matric head
   real(rkind),parameter        :: xSmall=1.e-0_rkind      ! a small offset
@@ -1235,7 +1235,7 @@ contains
    ! print progress towards solution
    if (globalPrintFlag) then
     write(*,'(a,1x,i4,1x,7(e15.5,1x),7(L1,1x))') 'check convergence: ', iter, &
-     fNew, matric_max(1), liquid_max(1), energy_max(1), canopy_max, aquifer_max, soilWatBalErr, matricConv, liquidConv, energyConv, watbalConv, canopyConv, aquiferConv, watbalConv
+     fnew, matric_max(1), liquid_max(1), energy_max(1), canopy_max, aquifer_max, soilWatBalErr, matricConv, liquidConv, energyConv, watbalConv, canopyConv, aquiferConv, watbalConv
    end if
 
   end associate ! end associations with variables in the data structures

--- a/build/source/engine/summaSolve4homegrown.f90
+++ b/build/source/engine/summaSolve4homegrown.f90
@@ -95,6 +95,7 @@ USE mDecisions_module,only:       &
 implicit none
 private
 public::summaSolve4homegrown
+public::checkConv
 contains
 
  ! **************************************************************************************************************************
@@ -504,7 +505,7 @@ contains
 
     ! check convergence
     ! NOTE: some efficiency gains possible by scaling the full newton step outside the line search loop
-    converged = checkConv(resVecNew,newtStepScaled*xScale,stateVecNew)
+    converged = checkConv(mSoil,in_SS4HG,mpar_data,indx_data,prog_data,resVecNew,newtStepScaled*xScale,stateVecNew,out_SS4HG)
     if(converged) return
 
     ! early return if not computing the line search
@@ -760,7 +761,7 @@ contains
    if (.not.feasible) then; err=20; message=trim(message)//'state vector not feasible'; return; end if
 
    ! check convergence
-   converged = checkConv(resVecNew,xInc,stateVecNew)
+   converged = checkConv(mSoil,in_SS4HG,mpar_data,indx_data,prog_data,resVecNew,xInc,stateVecNew,out_SS4HG)
 
   end associate
 
@@ -1107,17 +1108,25 @@ contains
   
   end subroutine eval8summa_wrapper
 
+ end subroutine summaSolve4homegrown
 
-  ! *********************************************************************************************************
-  ! internal function checkConv: check convergence based on the residual vector
-  ! *********************************************************************************************************
-  function checkConv(rVec,xInc,xVec)
+ ! *********************************************************************************************************
+ ! module function checkConv: check convergence based on the residual vector
+ ! *********************************************************************************************************
+ function checkConv(mSoil,in_SS4HG,mpar_data,indx_data,prog_data,rVec,xInc,xVec,out_SS4HG)
   implicit none
+  ! result
+  logical(lgt)                 :: checkConv                    ! flag to denote convergence
   ! dummies
-  real(rkind),intent(in)       :: rVec(:)                 ! residual vector (mixed units)
-  real(rkind),intent(in)       :: xInc(:)                 ! iteration increment (mixed units)
-  real(rkind),intent(in)       :: xVec(:)                 ! state vector (mixed units)
-  logical(lgt)                 :: checkConv               ! flag to denote convergence
+  integer(i4b),intent(in)      :: mSoil                        ! number of soil layers in solution vector
+  type(in_type_summaSolve4homegrown),intent(in) :: in_SS4HG    ! model control variables and previous function evaluation
+  type(var_dlength),intent(in) :: mpar_data                    ! model parameters
+  type(var_ilength),intent(in) :: indx_data                    ! indices defining model states and layers
+  type(var_dlength),intent(in) :: prog_data                    ! prognostic variables for a local HRU
+  real(rkind),intent(in)       :: rVec(:)                      ! residual vector (mixed units)
+  real(rkind),intent(in)       :: xInc(:)                      ! iteration increment (mixed units)
+  real(rkind),intent(in)       :: xVec(:)                      ! state vector (mixed units)
+  type(out_type_summaSolve4homegrown),intent(out) :: out_SS4HG ! new function evaluation, convergence flag, and error control
   ! locals
   real(rkind),dimension(mSoil) :: psiScale                ! scaling factor for matric head
   real(rkind),parameter        :: xSmall=1.e-0_rkind      ! a small offset
@@ -1157,85 +1166,80 @@ contains
    ixMatOnly               => indx_data%var(iLookINDEX%ixMatOnly)%dat           ,&  ! intent(in): [i4b(:)] list of indices for matric head state variables in the state vector
    ixMatricHead            => indx_data%var(iLookINDEX%ixMatricHead)%dat        ,&  ! intent(in): [i4b(:)] list of indices for matric head in the soil vector
    fnew                    => out_SS4HG % fnew                                   &  ! intent(in): [dp] new function evaluations
-  ) ! making associations with variables in the data structures
-  ! -------------------------------------------------------------------------------------------------------------------------------------------------
+  &) 
 
-  ! check convergence based on the canopy water balance
-  if(ixVegHyd/=integerMissing)then
-   canopy_max = real(abs(rVec(ixVegHyd)), rkind)*iden_water
-   canopyConv = (canopy_max    < absConvTol_liquid)  ! absolute error in canopy water balance (mm)
-  else
-   canopy_max = realMissing
-   canopyConv = .true.
-  endif
-
-  ! check convergence based on the residuals for energy (J m-3)
-  if(size(ixNrgOnly)>0)then
-   energy_max = real(maxval(abs( rVec(ixNrgOnly) )), rkind)
-   energyConv = (energy_max(1) < absConvTol_energy)  ! (based on the residual)
-  else
-   energy_max = realMissing
-   energyConv = .true.
-  endif
-
-  ! check convergence based on the residuals for volumetric liquid water content (-)
-  if(size(ixHydOnly)>0)then
-   liquid_max = real(maxval(abs( rVec(ixHydOnly) ) ), rkind)
-   ! (tighter convergence for the scalar solution)
-   if(scalarSolution)then
-    liquidConv = (liquid_max(1) < absConvTol_liquid*scalarTighten)   ! (based on the residual)
+   ! check convergence based on the canopy water balance
+   if (ixVegHyd/=integerMissing) then
+    canopy_max = real(abs(rVec(ixVegHyd)), rkind)*iden_water
+    canopyConv = (canopy_max    < absConvTol_liquid)  ! absolute error in canopy water balance (mm)
    else
-    liquidConv = (liquid_max(1) < absConvTol_liquid)                 ! (based on the residual)
-   endif
-  else
-   liquid_max = realMissing
-   liquidConv = .true.
-  endif
+    canopy_max = realMissing
+    canopyConv = .true.
+   end if
 
-  ! check convergence based on the iteration increment for matric head
-  ! NOTE: scale by matric head to avoid unnecessairly tight convergence when there is no water
-  if(size(ixMatOnly)>0)then
-   psiScale   = abs( xVec(ixMatOnly) ) + xSmall ! avoid divide by zero
-   matric_max = maxval(abs( xInc(ixMatOnly)/psiScale ) )
-   matricConv = (matric_max(1) < absConvTol_matric)  ! NOTE: based on iteration increment
-  else
-   matric_max = realMissing
-   matricConv = .true.
-  endif
+   ! check convergence based on the residuals for energy (J m-3)
+   if (size(ixNrgOnly)>0) then
+    energy_max = real(maxval(abs( rVec(ixNrgOnly) )), rkind)
+    energyConv = (energy_max(1) < absConvTol_energy)  ! (based on the residual)
+   else
+    energy_max = realMissing
+    energyConv = .true.
+   end if
 
-  ! check convergence based on the soil water balance error (m)
-  if(size(ixMatOnly)>0)then
-   soilWatBalErr = sum( real(rVec(ixMatOnly), rkind)*mLayerDepth(nSnow+ixMatricHead) )
-   watbalConv    = (abs(soilWatbalErr) < absConvTol_liquid)  ! absolute error in total soil water balance (m)
-  else
-   soilWatbalErr = realMissing
-   watbalConv    = .true.
-  endif
+   ! check convergence based on the residuals for volumetric liquid water content (-)
+   if (size(ixHydOnly)>0) then
+    liquid_max = real(maxval(abs( rVec(ixHydOnly) ) ), rkind)
+    ! (tighter convergence for the scalar solution)
+    if (scalarSolution) then
+     liquidConv = (liquid_max(1) < absConvTol_liquid*scalarTighten)   ! (based on the residual)
+    else
+     liquidConv = (liquid_max(1) < absConvTol_liquid)                 ! (based on the residual)
+    end if
+   else
+    liquid_max = realMissing
+    liquidConv = .true.
+   end if
 
-  ! check convergence based on the aquifer storage
-  if(ixAqWat/=integerMissing)then
-   aquifer_max = real(abs(rVec(ixAqWat)), rkind)*iden_water
-   aquiferConv = (aquifer_max    < absConvTol_liquid)  ! absolute error in aquifer water balance (mm)
-  else
-   aquifer_max = realMissing
-   aquiferConv = .true.
-  endif
+   ! check convergence based on the iteration increment for matric head
+   ! NOTE: scale by matric head to avoid unnecessairly tight convergence when there is no water
+   if (size(ixMatOnly)>0) then
+    psiScale   = abs( xVec(ixMatOnly) ) + xSmall ! avoid divide by zero
+    matric_max = maxval(abs( xInc(ixMatOnly)/psiScale ) )
+    matricConv = (matric_max(1) < absConvTol_matric)  ! NOTE: based on iteration increment
+   else
+    matric_max = realMissing
+    matricConv = .true.
+   end if
 
-  ! final convergence check
-  checkConv = (canopyConv .and. watbalConv .and. matricConv .and. liquidConv .and. energyConv .and. aquiferConv)
+   ! check convergence based on the soil water balance error (m)
+   if (size(ixMatOnly)>0) then
+    soilWatBalErr = sum( real(rVec(ixMatOnly), rkind)*mLayerDepth(nSnow+ixMatricHead) )
+    watbalConv    = (abs(soilWatbalErr) < absConvTol_liquid)  ! absolute error in total soil water balance (m)
+   else
+    soilWatbalErr = realMissing
+    watbalConv    = .true.
+   end if
 
-  ! print progress towards solution
-  if(globalPrintFlag)then
-   write(*,'(a,1x,i4,1x,7(e15.5,1x),7(L1,1x))') 'check convergence: ', iter, &
-    fNew, matric_max(1), liquid_max(1), energy_max(1), canopy_max, aquifer_max, soilWatBalErr, matricConv, liquidConv, energyConv, watbalConv, canopyConv, aquiferConv, watbalConv
-  endif
+   ! check convergence based on the aquifer storage
+   if (ixAqWat/=integerMissing) then
+    aquifer_max = real(abs(rVec(ixAqWat)), rkind)*iden_water
+    aquiferConv = (aquifer_max    < absConvTol_liquid)  ! absolute error in aquifer water balance (mm)
+   else
+    aquifer_max = realMissing
+    aquiferConv = .true.
+   end if
 
-  ! end associations with variables in the data structures
-  end associate
+   ! final convergence check
+   checkConv = (canopyConv .and. watbalConv .and. matricConv .and. liquidConv .and. energyConv .and. aquiferConv)
 
-  end function checkConv
+   ! print progress towards solution
+   if (globalPrintFlag) then
+    write(*,'(a,1x,i4,1x,7(e15.5,1x),7(L1,1x))') 'check convergence: ', iter, &
+     fNew, matric_max(1), liquid_max(1), energy_max(1), canopy_max, aquifer_max, soilWatBalErr, matricConv, liquidConv, energyConv, watbalConv, canopyConv, aquiferConv, watbalConv
+   end if
 
- end subroutine summaSolve4homegrown
+  end associate ! end associations with variables in the data structures
 
+ end function checkConv
 
 end module summaSolve4homegrown_module


### PR DESCRIPTION
Hi @ashleymedin - To avoid coding conflicts in `summaSolve4homegrown`, this PR includes changes that were made to grant external accessibility to the `checkConv` function. Specifically, `checkConv` was changed from an internal procedure to a module procedure with public access. The original motivation for this was done to allow access to the nested Newton solver (which is not in this PR but may be included in a future one).

Test suite output and resource use did not change. Tests included the new FUSE surface runoff parameterizations.

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] Closes #xxx (identify the issue associated with this PR)
- [x] Code passes standard test cases (results are either bit-for-bit identical, or differences are explained in the PR comment)
- [ ] New tests added (describe which tests were performed to test the changes)
- [ ] Science test figures (add figures to PR comment and describe the tests)
- [ ] Checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] Describe the change in the release notes (use  `./summa/docs/whats-new.md`)