### PR TITLE
Updates to summaSolve4homegrown for external access to getBrackets procedure 

### DIFF
--- a/build/source/engine/summaSolve4homegrown.f90
+++ b/build/source/engine/summaSolve4homegrown.f90
@@ -1000,104 +1000,104 @@ contains
                               &lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
                               &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
                               &fluxVecNew,resSinkNew,resVecNew,fNew,feasible,err,message)
- USE eval8summa_module,only:eval8summa                        ! simulation of fluxes and residuals given a trial state vector
- implicit none
- ! input
- real(rkind),intent(in)          :: stateVecNew(:)            ! updated state vector
- real(rkind),intent(in)          :: fScale(:)                 ! characteristic scale of the function evaluations
- type(in_type_summaSolve4homegrown),intent(in) :: in_SS4HG    ! model control variables and previous function evaluation
- type(model_options),intent(in)  :: model_decisions(:)        ! model decisions
- type(zLookup),      intent(in)  :: lookup_data               ! lookup tables
- type(var_i),        intent(in)  :: type_data                 ! type of vegetation and soil
- type(var_d),        intent(in)  :: attr_data                 ! spatial attributes
- type(var_dlength),  intent(in)  :: mpar_data                 ! model parameters
- type(var_d),        intent(in)  :: forc_data                 ! model forcing data
- type(var_dlength),  intent(in)  :: bvar_data                 ! model variables for the local basin
- type(var_dlength),  intent(in)  :: prog_data                 ! prognostic variables for a local HRU
- ! input-output
- real(qp),intent(inout)          :: sMul(:)   ! NOTE: qp      ! state vector multiplier (used in the residual calculations)
- type(io_type_summaSolve4homegrown),intent(inout) :: io_SS4HG ! model control variables and previous function evaluation
- type(var_ilength),intent(inout) :: indx_data                 ! indices defining model states and layers
- type(var_dlength),intent(inout) :: diag_data                 ! diagnostic variables for a local HRU
- type(var_dlength),intent(inout) :: flux_data                 ! model fluxes for a local HRU
- type(var_dlength),intent(inout) :: deriv_data                ! derivatives in model fluxes w.r.t. relevant state variables
- real(rkind),intent(inout)       :: dBaseflow_dMatric(:,:)    ! derivative in baseflow w.r.t. matric head (s-1)
- ! output
- real(rkind),intent(out)         :: fluxVecNew(:)             ! updated flux vector
- real(rkind),intent(out)         :: resSinkNew(:)             ! sink terms on the RHS of the flux equation
- real(qp),intent(out)            :: resVecNew(:) ! NOTE: qp   ! updated residual vector
- real(rkind),intent(out)         :: fNew                      ! new function value
- logical(lgt),intent(out)        :: feasible                  ! flag to denote the feasibility of the solution
- integer(i4b),intent(out)        :: err                       ! error code
- character(*),intent(out)        :: message                   ! error message
- ! ----------------------------------------------------------------------------------------------------------
- ! local
- !real(rkind),allocatable         :: fRHS(:)                   ! RHS function for ARKODE
- character(len=256)              :: cmessage                  ! error message of downwind routine
- ! ----------------------------------------------------------------------------------------------------------
- ! initialize error control
- err=0; message='eval8summa_wrapper/'
+  USE eval8summa_module,only:eval8summa                        ! simulation of fluxes and residuals given a trial state vector
+  implicit none
+  ! input
+  real(rkind),intent(in)          :: stateVecNew(:)            ! updated state vector
+  real(rkind),intent(in)          :: fScale(:)                 ! characteristic scale of the function evaluations
+  type(in_type_summaSolve4homegrown),intent(in) :: in_SS4HG    ! model control variables and previous function evaluation
+  type(model_options),intent(in)  :: model_decisions(:)        ! model decisions
+  type(zLookup),      intent(in)  :: lookup_data               ! lookup tables
+  type(var_i),        intent(in)  :: type_data                 ! type of vegetation and soil
+  type(var_d),        intent(in)  :: attr_data                 ! spatial attributes
+  type(var_dlength),  intent(in)  :: mpar_data                 ! model parameters
+  type(var_d),        intent(in)  :: forc_data                 ! model forcing data
+  type(var_dlength),  intent(in)  :: bvar_data                 ! model variables for the local basin
+  type(var_dlength),  intent(in)  :: prog_data                 ! prognostic variables for a local HRU
+  ! input-output
+  real(qp),intent(inout)          :: sMul(:)   ! NOTE: qp      ! state vector multiplier (used in the residual calculations)
+  type(io_type_summaSolve4homegrown),intent(inout) :: io_SS4HG ! model control variables and previous function evaluation
+  type(var_ilength),intent(inout) :: indx_data                 ! indices defining model states and layers
+  type(var_dlength),intent(inout) :: diag_data                 ! diagnostic variables for a local HRU
+  type(var_dlength),intent(inout) :: flux_data                 ! model fluxes for a local HRU
+  type(var_dlength),intent(inout) :: deriv_data                ! derivatives in model fluxes w.r.t. relevant state variables
+  real(rkind),intent(inout)       :: dBaseflow_dMatric(:,:)    ! derivative in baseflow w.r.t. matric head (s-1)
+  ! output
+  real(rkind),intent(out)         :: fluxVecNew(:)             ! updated flux vector
+  real(rkind),intent(out)         :: resSinkNew(:)             ! sink terms on the RHS of the flux equation
+  real(qp),intent(out)            :: resVecNew(:) ! NOTE: qp   ! updated residual vector
+  real(rkind),intent(out)         :: fNew                      ! new function value
+  logical(lgt),intent(out)        :: feasible                  ! flag to denote the feasibility of the solution
+  integer(i4b),intent(out)        :: err                       ! error code
+  character(*),intent(out)        :: message                   ! error message
+  ! ----------------------------------------------------------------------------------------------------------
+  ! local
+  !real(rkind),allocatable         :: fRHS(:)                   ! RHS function for ARKODE
+  character(len=256)              :: cmessage                  ! error message of downwind routine
+  ! ----------------------------------------------------------------------------------------------------------
+  ! initialize error control
+  err=0; message='eval8summa_wrapper/'
 
- associate(&
-  dt_cur         => in_SS4HG % dt_cur         ,& ! intent(in): current stepsize
-  dt             => in_SS4HG % dt             ,& ! intent(in): entire time step for drainage pond rate
-  nSnow          => in_SS4HG % nSnow          ,& ! intent(in): number of snow layers
-  nSoil          => in_SS4HG % nSoil          ,& ! intent(in): number of soil layers
-  nLayers        => in_SS4HG % nLayers        ,& ! intent(in): total number of layers
-  nState         => in_SS4HG % nState         ,& ! intent(in): total number of state variables
-  firstSubStep   => in_SS4HG % firstSubStep   ,& ! intent(in): flag to indicate if we are processing the first sub-step
-  computeVegFlux => in_SS4HG % computeVegFlux ,& ! intent(in): flag to indicate if computing fluxes over vegetation
-  scalarSolution => in_SS4HG % scalarSolution ,& ! intent(in): flag to denote if implementing the scalar solution
-  firstFluxCall  => io_SS4HG % firstFluxCall  ,& ! intent(inout): flag to indicate if we are processing the first flux call  
-  ixSaturation   => io_SS4HG % ixSaturation    & ! intent(inout): index of the lowest saturated layer (NOTE: only computed on the first iteration)    
- &)
- ! compute the flux and the residual vector for a given state vector
-  call eval8summa(&
-                  ! input: model control
-                  dt_cur,                  & ! intent(in):    current stepsize
-                  dt,                      & ! intent(in):    length of the time step (seconds)
-                  nSnow,                   & ! intent(in):    number of snow layers
-                  nSoil,                   & ! intent(in):    number of soil layers
-                  nLayers,                 & ! intent(in):    total number of layers
-                  nState,                  & ! intent(in):    total number of state variables
-                  .false.,                 & ! intent(in):    not inside Sundials solver
-                  firstSubStep,            & ! intent(in):    flag to indicate if we are processing the first sub-step
-                  firstFluxCall,           & ! intent(inout): flag to indicate if we are processing the first flux call
-                  .false.,                 & ! intent(in):    not processing the first iteration in a splitting operation
-                  computeVegFlux,          & ! intent(in):    flag to indicate if we need to compute fluxes over vegetation
-                  scalarSolution,          & ! intent(in):    flag to indicate the scalar solution
-                  ! input: state vectors
-                  stateVecNew,             & ! intent(in):    updated model state vector
-                  fScale,                  & ! intent(in):    characteristic scale of the function evaluations
-                  sMul,                    & ! intent(inout): state vector multiplier (used in the residual calculations)
-                  ! input: data structures
-                  model_decisions,         & ! intent(in):    model decisions
-                  lookup_data,             & ! intent(in):    lookup tables
-                  type_data,               & ! intent(in):    type of vegetation and soil
-                  attr_data,               & ! intent(in):    spatial attributes
-                  mpar_data,               & ! intent(in):    model parameters
-                  forc_data,               & ! intent(in):    model forcing data
-                  bvar_data,               & ! intent(in):    average model variables for the entire basin
-                  prog_data,               & ! intent(in):    model prognostic variables for a local HRU
-                  ! input-output: data structures
-                  indx_data,               & ! intent(inout): index data
-                  diag_data,               & ! intent(inout): model diagnostic variables for a local HRU
-                  flux_data,               & ! intent(inout): model fluxes for a local HRU
-                  deriv_data,              & ! intent(inout): derivatives in model fluxes w.r.t. relevant state variables
-                  ! input-output: baseflow
-                  ixSaturation,            & ! intent(inout): index of the lowest saturated layer (NOTE: only computed on the first iteration)
-                  dBaseflow_dMatric,       & ! intent(out):   derivative in baseflow w.r.t. matric head (s-1)
-                  ! output
-                  feasible,                & ! intent(out):   flag to denote the feasibility of the solution
-                  fluxVecNew,              & ! intent(out):   new flux vector
-                  !fRHS,                    & ! intent(out):   RHS function for ARKODE
-                  resSinkNew,              & ! intent(out):   additional (sink) terms on the RHS of the state equation
-                  resVecNew,               & ! intent(out):   new residual vector
-                  fNew,                    & ! intent(out):   new function evaluation
-                  err,cmessage)              ! intent(out):   error control
- end associate
+  associate(&
+   dt_cur         => in_SS4HG % dt_cur         ,& ! intent(in): current stepsize
+   dt             => in_SS4HG % dt             ,& ! intent(in): entire time step for drainage pond rate
+   nSnow          => in_SS4HG % nSnow          ,& ! intent(in): number of snow layers
+   nSoil          => in_SS4HG % nSoil          ,& ! intent(in): number of soil layers
+   nLayers        => in_SS4HG % nLayers        ,& ! intent(in): total number of layers
+   nState         => in_SS4HG % nState         ,& ! intent(in): total number of state variables
+   firstSubStep   => in_SS4HG % firstSubStep   ,& ! intent(in): flag to indicate if we are processing the first sub-step
+   computeVegFlux => in_SS4HG % computeVegFlux ,& ! intent(in): flag to indicate if computing fluxes over vegetation
+   scalarSolution => in_SS4HG % scalarSolution ,& ! intent(in): flag to denote if implementing the scalar solution
+   firstFluxCall  => io_SS4HG % firstFluxCall  ,& ! intent(inout): flag to indicate if we are processing the first flux call  
+   ixSaturation   => io_SS4HG % ixSaturation    & ! intent(inout): index of the lowest saturated layer (NOTE: only computed on the first iteration)    
+  &)
+   ! compute the flux and the residual vector for a given state vector
+   call eval8summa(&
+                   ! input: model control
+                   dt_cur,                  & ! intent(in):    current stepsize
+                   dt,                      & ! intent(in):    length of the time step (seconds)
+                   nSnow,                   & ! intent(in):    number of snow layers
+                   nSoil,                   & ! intent(in):    number of soil layers
+                   nLayers,                 & ! intent(in):    total number of layers
+                   nState,                  & ! intent(in):    total number of state variables
+                   .false.,                 & ! intent(in):    not inside Sundials solver
+                   firstSubStep,            & ! intent(in):    flag to indicate if we are processing the first sub-step
+                   firstFluxCall,           & ! intent(inout): flag to indicate if we are processing the first flux call
+                   .false.,                 & ! intent(in):    not processing the first iteration in a splitting operation
+                   computeVegFlux,          & ! intent(in):    flag to indicate if we need to compute fluxes over vegetation
+                   scalarSolution,          & ! intent(in):    flag to indicate the scalar solution
+                   ! input: state vectors
+                   stateVecNew,             & ! intent(in):    updated model state vector
+                   fScale,                  & ! intent(in):    characteristic scale of the function evaluations
+                   sMul,                    & ! intent(inout): state vector multiplier (used in the residual calculations)
+                   ! input: data structures
+                   model_decisions,         & ! intent(in):    model decisions
+                   lookup_data,             & ! intent(in):    lookup tables
+                   type_data,               & ! intent(in):    type of vegetation and soil
+                   attr_data,               & ! intent(in):    spatial attributes
+                   mpar_data,               & ! intent(in):    model parameters
+                   forc_data,               & ! intent(in):    model forcing data
+                   bvar_data,               & ! intent(in):    average model variables for the entire basin
+                   prog_data,               & ! intent(in):    model prognostic variables for a local HRU
+                   ! input-output: data structures
+                   indx_data,               & ! intent(inout): index data
+                   diag_data,               & ! intent(inout): model diagnostic variables for a local HRU
+                   flux_data,               & ! intent(inout): model fluxes for a local HRU
+                   deriv_data,              & ! intent(inout): derivatives in model fluxes w.r.t. relevant state variables
+                   ! input-output: baseflow
+                   ixSaturation,            & ! intent(inout): index of the lowest saturated layer (NOTE: only computed on the first iteration)
+                   dBaseflow_dMatric,       & ! intent(out):   derivative in baseflow w.r.t. matric head (s-1)
+                   ! output
+                   feasible,                & ! intent(out):   flag to denote the feasibility of the solution
+                   fluxVecNew,              & ! intent(out):   new flux vector
+                   !fRHS,                    & ! intent(out):   RHS function for ARKODE
+                   resSinkNew,              & ! intent(out):   additional (sink) terms on the RHS of the state equation
+                   resVecNew,               & ! intent(out):   new residual vector
+                   fNew,                    & ! intent(out):   new function evaluation
+                   err,cmessage)              ! intent(out):   error control
+  end associate
 
- if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! (check for errors)
+  if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
  
  end subroutine eval8summa_wrapper
 

--- a/build/source/engine/summaSolve4homegrown.f90
+++ b/build/source/engine/summaSolve4homegrown.f90
@@ -495,7 +495,7 @@ contains
     call eval8summa_wrapper(stateVecNew,fScale,in_SS4HG,model_decisions,&
                            &lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
                            &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
-                           &fluxVecNew,resSinkNew,resVecNew,fNew,feasible,err,message)
+                           &fluxVecNew,resSinkNew,resVecNew,fNew,feasible,err,cmessage)
     if(err/=0)then; message=trim(message)//trim(cmessage); return; end if  ! (check for errors)
 
     ! check line search
@@ -731,7 +731,10 @@ contains
 
     ! get brackets if they do not exist
     if ( ieee_is_nan(xMin) .or. ieee_is_nan(xMax) ) then
-     call getBrackets(stateVecTrial,stateVecNew,xMin,xMax,err,cmessage)
+     call getBrackets(stateVecTrial,rvec,fScale,in_SS4HG,model_decisions,lookup_data,type_data,attr_data,&
+                     &mpar_data,forc_data,bvar_data,prog_data,&
+                     &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
+                     &out_SS4HG,stateVecNew,fluxVecNew,resSinkNew,resVecNew,xMin,xMax,err,cmessage)
      if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
     end if
 
@@ -764,7 +767,7 @@ contains
    call eval8summa_wrapper(stateVecNew,fScale,in_SS4HG,model_decisions,&
                           &lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
                           &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
-                          &fluxVecNew,resSinkNew,resVecNew,fNew,feasible,err,message)
+                          &fluxVecNew,resSinkNew,resVecNew,fNew,feasible,err,cmessage)
    if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
 
    ! check feasibility (should be feasible because of the call to imposeConstraints, except if canopyTemp>canopyTempMax (500._rkind)) 
@@ -777,86 +780,6 @@ contains
 
   end subroutine safeRootfinder
 
-  ! *********************************************************************************************************
-  ! * internal subroutine getBrackets: get the brackets
-  ! *********************************************************************************************************
-  subroutine getBrackets(stateVecTrial,stateVecNew,xMin,xMax,err,message)
-  USE,intrinsic :: ieee_arithmetic,only:ieee_is_nan          ! IEEE arithmetic (check NaN)
-  implicit none
-  ! dummies
-  real(rkind),intent(in)         :: stateVecTrial(:)         ! trial state vector
-  real(rkind),intent(out)        :: stateVecNew(:)           ! new state vector
-  real(rkind),intent(out)        :: xMin,xMax                ! constraints
-  integer(i4b),intent(inout)     :: err                      ! error code
-  character(*),intent(out)       :: message                  ! error message
-  ! locals
-  real(rkind)                    :: stateVecPrev(in_SS4HG % nState) ! iteration state vector
-  integer(i4b)                   :: iCheck                          ! check the model state variables
-  integer(i4b),parameter         :: nCheck=100                      ! number of times to check the model state variables
-  logical(lgt)                   :: feasible                        ! feasibility of the solution
-  real(rkind),parameter          :: delX=1._rkind                   ! trial increment
-  real(rkind)                    :: xIncrement(in_SS4HG % nState)   ! trial increment
-  ! initialize
-  err=0; message='getBrackets/'
-
-  ! initialize state vector
-  stateVecNew = stateVecTrial
-  stateVecPrev = stateVecNew
-
-  ! get xIncrement
-  xIncrement = -sign((/delX/),rVec)
-
-  ! try the increment a few times
-  do iCheck=1,nCheck
-
-   ! state vector with proposed iteration increment
-   stateVecNew = stateVecPrev + xIncrement
-
-   ! impose solution constraints adjusting state vector and iteration increment
-   associate(&
-    nSnow          => in_SS4HG % nSnow          ,& ! intent(in): number of snow layers
-    nSoil          => in_SS4HG % nSoil          ,& ! intent(in): number of soil layers
-    nState         => in_SS4HG % nState          & ! intent(in): total number of state variables
-   &)
-    call imposeConstraints(model_decisions,indx_data,prog_data,mpar_data,stateVecNew,stateVecPrev,nState,nSoil,nSnow,cmessage,err)
-   end associate
-   if(err/=0)then; message=trim(message)//trim(cmessage); return; end if  ! (check for errors)
-   xIncrement = stateVecNew - stateVecPrev
-
-   ! evaluate summa
-   associate(fnew => out_SS4HG % fnew)
-    call eval8summa_wrapper(stateVecNew,fScale,in_SS4HG,model_decisions,&
-                           &lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
-                           &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
-                           &fluxVecNew,resSinkNew,resVecNew,fNew,feasible,err,message)
-   end associate
-   if(err/=0)then; message=trim(message)//trim(cmessage); return; end if  ! (check for errors)
-
-   ! check feasibility (should be feasible because of the call to imposeConstraints, except if canopyTemp>canopyTempMax (500._rkind)) 
-   if(.not.feasible)then; message=trim(message)//'state vector not feasible'; err=20; return; endif
-
-   ! update brackets
-   if(real(resVecNew(1), rkind)<0._rkind)then
-    xMin = stateVecNew(1)
-   else
-    xMax = stateVecNew(1)
-   endif
-
-   ! check that the brackets are defined
-   if( .not.ieee_is_nan(xMin) .and. .not.ieee_is_nan(xMax) ) exit
-
-   ! check that we found the brackets
-   if(iCheck==nCheck)then
-    message=trim(message)//'could not fix the problem where residual and iteration increment are of the same sign'
-    err=20; return
-   endif
-
-   ! Save the state vector
-    stateVecPrev = stateVecNew
-
-  end do  ! multiple checks
-
-  end subroutine getBrackets
 
  end subroutine summaSolve4homegrown
 
@@ -993,6 +916,116 @@ contains
  end function checkConv
 
  ! *********************************************************************************************************
+ ! * module subroutine getBrackets: get the brackets for safeRootfinder
+ ! *********************************************************************************************************
+ subroutine getBrackets(stateVecTrial,rvec,fScale,in_SS4HG,model_decisions,lookup_data,type_data,attr_data,&
+                       &mpar_data,forc_data,bvar_data,prog_data,&
+                       &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
+                       &out_SS4HG,stateVecNew,fluxVecNew,resSinkNew,resVecNew,xMin,xMax,err,message)
+  USE,intrinsic :: ieee_arithmetic,only:ieee_is_nan            ! IEEE arithmetic (check NaN)
+  USE eval8summa_module,only: imposeConstraints                ! imposeConstraints
+  implicit none
+  ! input
+  real(rkind),intent(in)          :: stateVecTrial(:)          ! trial state vector
+  real(qp),intent(in)             :: rVec(:)   ! NOTE: qp      ! residual vector
+  real(rkind),intent(in)          :: fScale(:)                 ! characteristic scale of the function evaluations
+  type(in_type_summaSolve4homegrown),intent(in) :: in_SS4HG    ! model control variables and previous function evaluation
+  type(model_options),intent(in)  :: model_decisions(:)        ! model decisions
+  type(zLookup),      intent(in)  :: lookup_data               ! lookup tables
+  type(var_i),        intent(in)  :: type_data                 ! type of vegetation and soil
+  type(var_d),        intent(in)  :: attr_data                 ! spatial attributes
+  type(var_dlength),  intent(in)  :: mpar_data                 ! model parameters
+  type(var_d),        intent(in)  :: forc_data                 ! model forcing data
+  type(var_dlength),  intent(in)  :: bvar_data                 ! model variables for the local basin
+  type(var_dlength),  intent(in)  :: prog_data                 ! prognostic variables for a local HRU
+  ! input-output
+  real(qp),intent(inout)          :: sMul(:)   ! NOTE: qp      ! state vector multiplier (used in the residual calculations)
+  type(io_type_summaSolve4homegrown),intent(inout) :: io_SS4HG ! first flux call flag and baseflow variables
+  type(var_ilength),intent(inout) :: indx_data                 ! indices defining model states and layers
+  type(var_dlength),intent(inout) :: diag_data                 ! diagnostic variables for a local HRU
+  type(var_dlength),intent(inout) :: flux_data                 ! model fluxes for a local HRU
+  type(var_dlength),intent(inout) :: deriv_data                ! derivatives in model fluxes w.r.t. relevant state variables
+  real(rkind),intent(inout)       :: dBaseflow_dMatric(:,:)    ! derivative in baseflow w.r.t. matric head (s-1)
+  integer(i4b),intent(inout)      :: err                       ! error code
+  ! output
+  type(out_type_summaSolve4homegrown),intent(out) :: out_SS4HG ! new function evaluation, convergence flag, and error control
+  real(rkind),intent(out)         :: stateVecNew(:)            ! new state vector
+  real(rkind),intent(out)         :: fluxVecNew(:)             ! updated flux vector
+  real(rkind),intent(out)         :: resSinkNew(:)             ! sink terms on the RHS of the flux equation
+  real(qp),intent(out)            :: resVecNew(:) ! NOTE: qp   ! updated residual vector
+  real(rkind),intent(out)         :: xMin,xMax                 ! constraints
+  character(*),intent(out)        :: message                   ! error message
+  ! locals
+  real(rkind)                     :: stateVecPrev(in_SS4HG % nState) ! iteration state vector
+  integer(i4b)                    :: iCheck                          ! check the model state variables
+  integer(i4b),parameter          :: nCheck=100                      ! number of times to check the model state variables
+  logical(lgt)                    :: feasible                        ! feasibility of the solution
+  real(rkind),parameter           :: delX=1._rkind                   ! trial increment
+  real(rkind)                     :: xIncrement(in_SS4HG % nState)   ! trial increment
+  character(len=256)              :: cmessage                        ! error message of downwind routine
+  ! initialize
+  err=0; message='getBrackets/'
+
+  ! initialize state vector
+  stateVecNew = stateVecTrial
+  stateVecPrev = stateVecNew
+
+  ! get xIncrement
+  xIncrement = -sign((/delX/),rVec)
+
+  ! try the increment a few times
+  do iCheck=1,nCheck
+
+   ! state vector with proposed iteration increment
+   stateVecNew = stateVecPrev + xIncrement
+
+   ! impose solution constraints adjusting state vector and iteration increment
+   associate(&
+    nSnow          => in_SS4HG % nSnow          ,& ! intent(in): number of snow layers
+    nSoil          => in_SS4HG % nSoil          ,& ! intent(in): number of soil layers
+    nState         => in_SS4HG % nState          & ! intent(in): total number of state variables
+   &)
+    call imposeConstraints(model_decisions,indx_data,prog_data,mpar_data,stateVecNew,stateVecPrev,nState,nSoil,nSnow,cmessage,err)
+   end associate
+   if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
+   xIncrement = stateVecNew - stateVecPrev
+
+   ! evaluate summa
+   associate(fnew => out_SS4HG % fnew)
+    call eval8summa_wrapper(stateVecNew,fScale,in_SS4HG,model_decisions,&
+                           &lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
+                           &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
+                           &fluxVecNew,resSinkNew,resVecNew,fNew,feasible,err,cmessage)
+   end associate
+   if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
+
+   ! check feasibility (should be feasible because of the call to imposeConstraints, except if canopyTemp>canopyTempMax (500._rkind)) 
+   if (.not.feasible) then; message=trim(message)//'state vector not feasible'; err=20; return; end if
+
+   ! update brackets
+   if (real(resVecNew(1), rkind)<0._rkind) then
+    xMin = stateVecNew(1)
+   else
+    xMax = stateVecNew(1)
+   end if
+
+   ! check that the brackets are defined
+   if ( .not.ieee_is_nan(xMin) .and. .not.ieee_is_nan(xMax) ) exit
+
+   ! check that we found the brackets
+   if (iCheck==nCheck) then
+    message=trim(message)//'could not fix the problem where residual and iteration increment are of the same sign'
+    err=20; return
+   endif
+
+   ! Save the state vector
+   stateVecPrev = stateVecNew
+
+  end do  ! multiple checks
+
+ end subroutine getBrackets
+
+ ! *********************************************************************************************************
  ! * module subroutine eval8summa_wrapper: compute the right-hand-side vector
  ! *********************************************************************************************************
  ! NOTE: This is simply a wrapper routine for eval8summa, to reduce the number of calling arguments
@@ -1016,7 +1049,7 @@ contains
   type(var_dlength),  intent(in)  :: prog_data                 ! prognostic variables for a local HRU
   ! input-output
   real(qp),intent(inout)          :: sMul(:)   ! NOTE: qp      ! state vector multiplier (used in the residual calculations)
-  type(io_type_summaSolve4homegrown),intent(inout) :: io_SS4HG ! model control variables and previous function evaluation
+  type(io_type_summaSolve4homegrown),intent(inout) :: io_SS4HG ! first flux call flag and baseflow variables
   type(var_ilength),intent(inout) :: indx_data                 ! indices defining model states and layers
   type(var_dlength),intent(inout) :: diag_data                 ! diagnostic variables for a local HRU
   type(var_dlength),intent(inout) :: flux_data                 ! model fluxes for a local HRU

--- a/build/source/engine/summaSolve4homegrown.f90
+++ b/build/source/engine/summaSolve4homegrown.f90
@@ -493,7 +493,11 @@ contains
     ! compute the residual vector and function
     ! NOTE: This calls eval8summa in an internal subroutine which has access to all data
     !       Hence, we only need to include the variables of interest in lineSearch
-    call eval8summa_wrapper(stateVecNew,fluxVecNew,resVecNew,fNew,feasible,err,cmessage)
+    !call eval8summa_wrapper(stateVecNew,fluxVecNew,resVecNew,fNew,feasible,err,cmessage)
+    call eval8summa_wrapper(stateVecNew,fScale,in_SS4HG,model_decisions,&
+                           &lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
+                           &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
+                           &fluxVecNew,resSinkNew,resVecNew,fNew,feasible,err,message)
     if(err/=0)then; message=trim(message)//trim(cmessage); return; end if  ! (check for errors)
 
     ! check line search
@@ -759,7 +763,11 @@ contains
    end if
 
    ! evaluate summa
-   call eval8summa_wrapper(stateVecNew,fluxVecNew,resVecNew,fNew,feasible,err,cmessage)
+   !call eval8summa_wrapper(stateVecNew,fluxVecNew,resVecNew,fNew,feasible,err,cmessage)
+   call eval8summa_wrapper(stateVecNew,fScale,in_SS4HG,model_decisions,&
+                          &lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
+                          &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
+                          &fluxVecNew,resSinkNew,resVecNew,fNew,feasible,err,message)
    if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
 
    ! check feasibility (should be feasible because of the call to imposeConstraints, except if canopyTemp>canopyTempMax (500._rkind)) 
@@ -820,7 +828,11 @@ contains
 
    ! evaluate summa
    associate(fnew => out_SS4HG % fnew)
-    call eval8summa_wrapper(stateVecNew,fluxVecNew,resVecNew,fNew,feasible,err,cmessage)
+    !call eval8summa_wrapper(stateVecNew,fluxVecNew,resVecNew,fNew,feasible,err,cmessage)
+    call eval8summa_wrapper(stateVecNew,fScale,in_SS4HG,model_decisions,&
+                           &lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
+                           &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
+                           &fluxVecNew,resSinkNew,resVecNew,fNew,feasible,err,message)
    end associate
    if(err/=0)then; message=trim(message)//trim(cmessage); return; end if  ! (check for errors)
 
@@ -850,92 +862,93 @@ contains
 
   end subroutine getBrackets
 
+ ! ! *********************************************************************************************************
+ ! ! * internal subroutine eval8summa_wrapper: compute the right-hand-side vector
+ ! ! *********************************************************************************************************
+ ! ! NOTE: This is simply a wrapper routine for eval8summa, to reduce the number of calling arguments
+ ! !       An internal subroutine, so have access to all data in the main subroutine
+ ! subroutine eval8summa_wrapper(stateVecNew,fluxVecNew,resVecNew,fNew,feasible,err,message)
+ ! USE eval8summa_module,only:eval8summa                      ! simulation of fluxes and residuals given a trial state vector
+ ! implicit none
+ ! ! input
+ ! real(rkind),intent(in)         :: stateVecNew(:)           ! updated state vector
+ ! ! output
+ ! real(rkind),intent(out)        :: fluxVecNew(:)            ! updated flux vector
+ ! real(qp),intent(out)           :: resVecNew(:) ! NOTE: qp  ! updated residual vector
+ ! real(rkind),intent(out)        :: fNew                     ! new function value
+ ! logical(lgt),intent(out)       :: feasible                 ! flag to denote the feasibility of the solution
+ ! integer(i4b),intent(out)       :: err                      ! error code
+ ! character(*),intent(out)       :: message                  ! error message
+ ! ! ----------------------------------------------------------------------------------------------------------
+ ! ! local
+ ! real(rkind),allocatable        :: fRHS(:)                  ! RHS function for ARKODE
+ ! character(len=256)             :: cmessage                 ! error message of downwind routine
+ ! ! ----------------------------------------------------------------------------------------------------------
+ ! ! initialize error control
+ ! err=0; message='eval8summa_wrapper/'
 
-  ! *********************************************************************************************************
-  ! * internal subroutine eval8summa_wrapper: compute the right-hand-side vector
-  ! *********************************************************************************************************
-  ! NOTE: This is simply a wrapper routine for eval8summa, to reduce the number of calling arguments
-  !       An internal subroutine, so have access to all data in the main subroutine
-  subroutine eval8summa_wrapper(stateVecNew,fluxVecNew,resVecNew,fNew,feasible,err,message)
-  USE eval8summa_module,only:eval8summa                      ! simulation of fluxes and residuals given a trial state vector
-  implicit none
-  ! input
-  real(rkind),intent(in)         :: stateVecNew(:)           ! updated state vector
-  ! output
-  real(rkind),intent(out)        :: fluxVecNew(:)            ! updated flux vector
-  real(qp),intent(out)           :: resVecNew(:) ! NOTE: qp  ! updated residual vector
-  real(rkind),intent(out)        :: fNew                     ! new function value
-  logical(lgt),intent(out)       :: feasible                 ! flag to denote the feasibility of the solution
-  integer(i4b),intent(out)       :: err                      ! error code
-  character(*),intent(out)       :: message                  ! error message
-  ! ----------------------------------------------------------------------------------------------------------
-  ! local
-  character(len=256)             :: cmessage                 ! error message of downwind routine
-  ! ----------------------------------------------------------------------------------------------------------
-  ! initialize error control
-  err=0; message='eval8summa_wrapper/'
+ ! associate(&
+ !  dt_cur         => in_SS4HG % dt_cur         ,& ! intent(in): current stepsize
+ !  dt             => in_SS4HG % dt             ,& ! intent(in): entire time step for drainage pond rate
+ !  nSnow          => in_SS4HG % nSnow          ,& ! intent(in): number of snow layers
+ !  nSoil          => in_SS4HG % nSoil          ,& ! intent(in): number of soil layers
+ !  nLayers        => in_SS4HG % nLayers        ,& ! intent(in): total number of layers
+ !  nState         => in_SS4HG % nState         ,& ! intent(in): total number of state variables
+ !  firstSubStep   => in_SS4HG % firstSubStep   ,& ! intent(in): flag to indicate if we are processing the first sub-step
+ !  computeVegFlux => in_SS4HG % computeVegFlux ,& ! intent(in): flag to indicate if computing fluxes over vegetation
+ !  scalarSolution => in_SS4HG % scalarSolution ,& ! intent(in): flag to denote if implementing the scalar solution
+ !  firstFluxCall  => io_SS4HG % firstFluxCall  ,& ! intent(inout): flag to indicate if we are processing the first flux call  
+ !  ixSaturation   => io_SS4HG % ixSaturation    & ! intent(inout): index of the lowest saturated layer (NOTE: only computed on the first iteration)    
+ ! &)
+ ! ! compute the flux and the residual vector for a given state vector
+ !  call eval8summa(&
+ !                  ! input: model control
+ !                  dt_cur,                  & ! intent(in):    current stepsize
+ !                  dt,                      & ! intent(in):    length of the time step (seconds)
+ !                  nSnow,                   & ! intent(in):    number of snow layers
+ !                  nSoil,                   & ! intent(in):    number of soil layers
+ !                  nLayers,                 & ! intent(in):    total number of layers
+ !                  nState,                  & ! intent(in):    total number of state variables
+ !                  .false.,                 & ! intent(in):    not inside Sundials solver
+ !                  firstSubStep,            & ! intent(in):    flag to indicate if we are processing the first sub-step
+ !                  firstFluxCall,           & ! intent(inout): flag to indicate if we are processing the first flux call
+ !                  .false.,                 & ! intent(in):    not processing the first iteration in a splitting operation
+ !                  computeVegFlux,          & ! intent(in):    flag to indicate if we need to compute fluxes over vegetation
+ !                  scalarSolution,          & ! intent(in):    flag to indicate the scalar solution
+ !                  ! input: state vectors
+ !                  stateVecNew,             & ! intent(in):    updated model state vector
+ !                  fScale,                  & ! intent(in):    characteristic scale of the function evaluations
+ !                  sMul,                    & ! intent(inout): state vector multiplier (used in the residual calculations)
+ !                  ! input: data structures
+ !                  model_decisions,         & ! intent(in):    model decisions
+ !                  lookup_data,             & ! intent(in):    lookup tables
+ !                  type_data,               & ! intent(in):    type of vegetation and soil
+ !                  attr_data,               & ! intent(in):    spatial attributes
+ !                  mpar_data,               & ! intent(in):    model parameters
+ !                  forc_data,               & ! intent(in):    model forcing data
+ !                  bvar_data,               & ! intent(in):    average model variables for the entire basin
+ !                  prog_data,               & ! intent(in):    model prognostic variables for a local HRU
+ !                  ! input-output: data structures
+ !                  indx_data,               & ! intent(inout): index data
+ !                  diag_data,               & ! intent(inout): model diagnostic variables for a local HRU
+ !                  flux_data,               & ! intent(inout): model fluxes for a local HRU
+ !                  deriv_data,              & ! intent(inout): derivatives in model fluxes w.r.t. relevant state variables
+ !                  ! input-output: baseflow
+ !                  ixSaturation,            & ! intent(inout): index of the lowest saturated layer (NOTE: only computed on the first iteration)
+ !                  dBaseflow_dMatric,       & ! intent(out):   derivative in baseflow w.r.t. matric head (s-1)
+ !                  ! output
+ !                  feasible,                & ! intent(out):   flag to denote the feasibility of the solution
+ !                  fluxVecNew,              & ! intent(out):   new flux vector
+ !                  fRHS,                    & ! intent(out):   RHS function for ARKODE
+ !                  resSinkNew,              & ! intent(out):   additional (sink) terms on the RHS of the state equation
+ !                  resVecNew,               & ! intent(out):   new residual vector
+ !                  fNew,                    & ! intent(out):   new function evaluation
+ !                  err,cmessage)              ! intent(out):   error control
+ ! end associate
 
-  associate(&
-   dt_cur         => in_SS4HG % dt_cur         ,& ! intent(in): current stepsize
-   dt             => in_SS4HG % dt             ,& ! intent(in): entire time step for drainage pond rate
-   nSnow          => in_SS4HG % nSnow          ,& ! intent(in): number of snow layers
-   nSoil          => in_SS4HG % nSoil          ,& ! intent(in): number of soil layers
-   nLayers        => in_SS4HG % nLayers        ,& ! intent(in): total number of layers
-   nState         => in_SS4HG % nState         ,& ! intent(in): total number of state variables
-   firstSubStep   => in_SS4HG % firstSubStep   ,& ! intent(in): flag to indicate if we are processing the first sub-step
-   computeVegFlux => in_SS4HG % computeVegFlux ,& ! intent(in): flag to indicate if computing fluxes over vegetation
-   scalarSolution => in_SS4HG % scalarSolution ,& ! intent(in): flag to denote if implementing the scalar solution
-   firstFluxCall  => io_SS4HG % firstFluxCall  ,& ! intent(inout): flag to indicate if we are processing the first flux call  
-   ixSaturation   => io_SS4HG % ixSaturation    & ! intent(inout): index of the lowest saturated layer (NOTE: only computed on the first iteration)    
-  &)
-  ! compute the flux and the residual vector for a given state vector
-   call eval8summa(&
-                   ! input: model control
-                   dt_cur,                  & ! intent(in):    current stepsize
-                   dt,                      & ! intent(in):    length of the time step (seconds)
-                   nSnow,                   & ! intent(in):    number of snow layers
-                   nSoil,                   & ! intent(in):    number of soil layers
-                   nLayers,                 & ! intent(in):    total number of layers
-                   nState,                  & ! intent(in):    total number of state variables
-                   .false.,                 & ! intent(in):    not inside Sundials solver
-                   firstSubStep,            & ! intent(in):    flag to indicate if we are processing the first sub-step
-                   firstFluxCall,           & ! intent(inout): flag to indicate if we are processing the first flux call
-                   .false.,                 & ! intent(in):    not processing the first iteration in a splitting operation
-                   computeVegFlux,          & ! intent(in):    flag to indicate if we need to compute fluxes over vegetation
-                   scalarSolution,          & ! intent(in):    flag to indicate the scalar solution
-                   ! input: state vectors
-                   stateVecNew,             & ! intent(in):    updated model state vector
-                   fScale,                  & ! intent(in):    characteristic scale of the function evaluations
-                   sMul,                    & ! intent(inout): state vector multiplier (used in the residual calculations)
-                   ! input: data structures
-                   model_decisions,         & ! intent(in):    model decisions
-                   lookup_data,             & ! intent(in):    lookup tables
-                   type_data,               & ! intent(in):    type of vegetation and soil
-                   attr_data,               & ! intent(in):    spatial attributes
-                   mpar_data,               & ! intent(in):    model parameters
-                   forc_data,               & ! intent(in):    model forcing data
-                   bvar_data,               & ! intent(in):    average model variables for the entire basin
-                   prog_data,               & ! intent(in):    model prognostic variables for a local HRU
-                   ! input-output: data structures
-                   indx_data,               & ! intent(inout): index data
-                   diag_data,               & ! intent(inout): model diagnostic variables for a local HRU
-                   flux_data,               & ! intent(inout): model fluxes for a local HRU
-                   deriv_data,              & ! intent(inout): derivatives in model fluxes w.r.t. relevant state variables
-                   ! input-output: baseflow
-                   ixSaturation,            & ! intent(inout): index of the lowest saturated layer (NOTE: only computed on the first iteration)
-                   dBaseflow_dMatric,       & ! intent(out):   derivative in baseflow w.r.t. matric head (s-1)
-                   ! output
-                   feasible,                & ! intent(out):   flag to denote the feasibility of the solution
-                   fluxVecNew,              & ! intent(out):   new flux vector
-                   resSinkNew,              & ! intent(out):   additional (sink) terms on the RHS of the state equation
-                   resVecNew,               & ! intent(out):   new residual vector
-                   fNew,                    & ! intent(out):   new function evaluation
-                   err,cmessage)              ! intent(out):   error control
-  end associate
-
-  if(err/=0)then; message=trim(message)//trim(cmessage); return; end if  ! (check for errors)
-  
-  end subroutine eval8summa_wrapper
+ ! if(err/=0)then; message=trim(message)//trim(cmessage); return; end if  ! (check for errors)
+ ! 
+ ! end subroutine eval8summa_wrapper
 
  end subroutine summaSolve4homegrown
 
@@ -1070,5 +1083,114 @@ contains
   end associate ! end associations with variables in the data structures
 
  end function checkConv
+
+ ! *********************************************************************************************************
+ ! * module subroutine eval8summa_wrapper: compute the right-hand-side vector
+ ! *********************************************************************************************************
+ ! NOTE: This is simply a wrapper routine for eval8summa, to reduce the number of calling arguments
+ subroutine eval8summa_wrapper(stateVecNew,fScale,in_SS4HG,model_decisions,&
+                              &lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
+                              &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
+                              &fluxVecNew,resSinkNew,resVecNew,fNew,feasible,err,message)
+ USE eval8summa_module,only:eval8summa                        ! simulation of fluxes and residuals given a trial state vector
+ implicit none
+ ! input
+ real(rkind),intent(in)          :: stateVecNew(:)            ! updated state vector
+ real(rkind),intent(in)          :: fScale(:)                 ! characteristic scale of the function evaluations
+ type(in_type_summaSolve4homegrown),intent(in) :: in_SS4HG    ! model control variables and previous function evaluation
+ type(model_options),intent(in)  :: model_decisions(:)        ! model decisions
+ type(zLookup),      intent(in)  :: lookup_data               ! lookup tables
+ type(var_i),        intent(in)  :: type_data                 ! type of vegetation and soil
+ type(var_d),        intent(in)  :: attr_data                 ! spatial attributes
+ type(var_dlength),  intent(in)  :: mpar_data                 ! model parameters
+ type(var_d),        intent(in)  :: forc_data                 ! model forcing data
+ type(var_dlength),  intent(in)  :: bvar_data                 ! model variables for the local basin
+ type(var_dlength),  intent(in)  :: prog_data                 ! prognostic variables for a local HRU
+ ! input-output
+ real(qp),intent(inout)          :: sMul(:)   ! NOTE: qp      ! state vector multiplier (used in the residual calculations)
+ type(io_type_summaSolve4homegrown),intent(inout) :: io_SS4HG ! model control variables and previous function evaluation
+ type(var_ilength),intent(inout) :: indx_data                 ! indices defining model states and layers
+ type(var_dlength),intent(inout) :: diag_data                 ! diagnostic variables for a local HRU
+ type(var_dlength),intent(inout) :: flux_data                 ! model fluxes for a local HRU
+ type(var_dlength),intent(inout) :: deriv_data                ! derivatives in model fluxes w.r.t. relevant state variables
+ real(rkind),intent(inout)       :: dBaseflow_dMatric(:,:)    ! derivative in baseflow w.r.t. matric head (s-1)
+ ! output
+ real(rkind),intent(out)         :: fluxVecNew(:)             ! updated flux vector
+ real(rkind),intent(out)         :: resSinkNew(:)             ! sink terms on the RHS of the flux equation
+ real(qp),intent(out)            :: resVecNew(:) ! NOTE: qp   ! updated residual vector
+ real(rkind),intent(out)         :: fNew                      ! new function value
+ logical(lgt),intent(out)        :: feasible                  ! flag to denote the feasibility of the solution
+ integer(i4b),intent(out)        :: err                       ! error code
+ character(*),intent(out)        :: message                   ! error message
+ ! ----------------------------------------------------------------------------------------------------------
+ ! local
+ real(rkind),allocatable         :: fRHS(:)                   ! RHS function for ARKODE
+ character(len=256)              :: cmessage                  ! error message of downwind routine
+ ! ----------------------------------------------------------------------------------------------------------
+ ! initialize error control
+ err=0; message='eval8summa_wrapper/'
+
+ associate(&
+  dt_cur         => in_SS4HG % dt_cur         ,& ! intent(in): current stepsize
+  dt             => in_SS4HG % dt             ,& ! intent(in): entire time step for drainage pond rate
+  nSnow          => in_SS4HG % nSnow          ,& ! intent(in): number of snow layers
+  nSoil          => in_SS4HG % nSoil          ,& ! intent(in): number of soil layers
+  nLayers        => in_SS4HG % nLayers        ,& ! intent(in): total number of layers
+  nState         => in_SS4HG % nState         ,& ! intent(in): total number of state variables
+  firstSubStep   => in_SS4HG % firstSubStep   ,& ! intent(in): flag to indicate if we are processing the first sub-step
+  computeVegFlux => in_SS4HG % computeVegFlux ,& ! intent(in): flag to indicate if computing fluxes over vegetation
+  scalarSolution => in_SS4HG % scalarSolution ,& ! intent(in): flag to denote if implementing the scalar solution
+  firstFluxCall  => io_SS4HG % firstFluxCall  ,& ! intent(inout): flag to indicate if we are processing the first flux call  
+  ixSaturation   => io_SS4HG % ixSaturation    & ! intent(inout): index of the lowest saturated layer (NOTE: only computed on the first iteration)    
+ &)
+ ! compute the flux and the residual vector for a given state vector
+  call eval8summa(&
+                  ! input: model control
+                  dt_cur,                  & ! intent(in):    current stepsize
+                  dt,                      & ! intent(in):    length of the time step (seconds)
+                  nSnow,                   & ! intent(in):    number of snow layers
+                  nSoil,                   & ! intent(in):    number of soil layers
+                  nLayers,                 & ! intent(in):    total number of layers
+                  nState,                  & ! intent(in):    total number of state variables
+                  .false.,                 & ! intent(in):    not inside Sundials solver
+                  firstSubStep,            & ! intent(in):    flag to indicate if we are processing the first sub-step
+                  firstFluxCall,           & ! intent(inout): flag to indicate if we are processing the first flux call
+                  .false.,                 & ! intent(in):    not processing the first iteration in a splitting operation
+                  computeVegFlux,          & ! intent(in):    flag to indicate if we need to compute fluxes over vegetation
+                  scalarSolution,          & ! intent(in):    flag to indicate the scalar solution
+                  ! input: state vectors
+                  stateVecNew,             & ! intent(in):    updated model state vector
+                  fScale,                  & ! intent(in):    characteristic scale of the function evaluations
+                  sMul,                    & ! intent(inout): state vector multiplier (used in the residual calculations)
+                  ! input: data structures
+                  model_decisions,         & ! intent(in):    model decisions
+                  lookup_data,             & ! intent(in):    lookup tables
+                  type_data,               & ! intent(in):    type of vegetation and soil
+                  attr_data,               & ! intent(in):    spatial attributes
+                  mpar_data,               & ! intent(in):    model parameters
+                  forc_data,               & ! intent(in):    model forcing data
+                  bvar_data,               & ! intent(in):    average model variables for the entire basin
+                  prog_data,               & ! intent(in):    model prognostic variables for a local HRU
+                  ! input-output: data structures
+                  indx_data,               & ! intent(inout): index data
+                  diag_data,               & ! intent(inout): model diagnostic variables for a local HRU
+                  flux_data,               & ! intent(inout): model fluxes for a local HRU
+                  deriv_data,              & ! intent(inout): derivatives in model fluxes w.r.t. relevant state variables
+                  ! input-output: baseflow
+                  ixSaturation,            & ! intent(inout): index of the lowest saturated layer (NOTE: only computed on the first iteration)
+                  dBaseflow_dMatric,       & ! intent(out):   derivative in baseflow w.r.t. matric head (s-1)
+                  ! output
+                  feasible,                & ! intent(out):   flag to denote the feasibility of the solution
+                  fluxVecNew,              & ! intent(out):   new flux vector
+                  fRHS,                    & ! intent(out):   RHS function for ARKODE
+                  resSinkNew,              & ! intent(out):   additional (sink) terms on the RHS of the state equation
+                  resVecNew,               & ! intent(out):   new residual vector
+                  fNew,                    & ! intent(out):   new function evaluation
+                  err,cmessage)              ! intent(out):   error control
+ end associate
+
+ if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! (check for errors)
+ 
+ end subroutine eval8summa_wrapper
 
 end module summaSolve4homegrown_module

--- a/build/source/engine/summaSolve4homegrown.f90
+++ b/build/source/engine/summaSolve4homegrown.f90
@@ -1124,7 +1124,7 @@ contains
  character(*),intent(out)        :: message                   ! error message
  ! ----------------------------------------------------------------------------------------------------------
  ! local
- real(rkind),allocatable         :: fRHS(:)                   ! RHS function for ARKODE
+ !real(rkind),allocatable         :: fRHS(:)                   ! RHS function for ARKODE
  character(len=256)              :: cmessage                  ! error message of downwind routine
  ! ----------------------------------------------------------------------------------------------------------
  ! initialize error control
@@ -1182,7 +1182,7 @@ contains
                   ! output
                   feasible,                & ! intent(out):   flag to denote the feasibility of the solution
                   fluxVecNew,              & ! intent(out):   new flux vector
-                  fRHS,                    & ! intent(out):   RHS function for ARKODE
+                  !fRHS,                    & ! intent(out):   RHS function for ARKODE
                   resSinkNew,              & ! intent(out):   additional (sink) terms on the RHS of the state equation
                   resVecNew,               & ! intent(out):   new residual vector
                   fNew,                    & ! intent(out):   new function evaluation

--- a/build/source/engine/summaSolve4homegrown.f90
+++ b/build/source/engine/summaSolve4homegrown.f90
@@ -491,9 +491,7 @@ contains
     xInc = stateVecNew - stateVecTrial
 
     ! compute the residual vector and function
-    ! NOTE: This calls eval8summa in an internal subroutine which has access to all data
-    !       Hence, we only need to include the variables of interest in lineSearch
-    !call eval8summa_wrapper(stateVecNew,fluxVecNew,resVecNew,fNew,feasible,err,cmessage)
+    ! NOTE: This calls eval8summa in a wrapper subroutine
     call eval8summa_wrapper(stateVecNew,fScale,in_SS4HG,model_decisions,&
                            &lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
                            &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
@@ -763,7 +761,6 @@ contains
    end if
 
    ! evaluate summa
-   !call eval8summa_wrapper(stateVecNew,fluxVecNew,resVecNew,fNew,feasible,err,cmessage)
    call eval8summa_wrapper(stateVecNew,fScale,in_SS4HG,model_decisions,&
                           &lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
                           &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
@@ -828,7 +825,6 @@ contains
 
    ! evaluate summa
    associate(fnew => out_SS4HG % fnew)
-    !call eval8summa_wrapper(stateVecNew,fluxVecNew,resVecNew,fNew,feasible,err,cmessage)
     call eval8summa_wrapper(stateVecNew,fScale,in_SS4HG,model_decisions,&
                            &lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
                            &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
@@ -861,94 +857,6 @@ contains
   end do  ! multiple checks
 
   end subroutine getBrackets
-
- ! ! *********************************************************************************************************
- ! ! * internal subroutine eval8summa_wrapper: compute the right-hand-side vector
- ! ! *********************************************************************************************************
- ! ! NOTE: This is simply a wrapper routine for eval8summa, to reduce the number of calling arguments
- ! !       An internal subroutine, so have access to all data in the main subroutine
- ! subroutine eval8summa_wrapper(stateVecNew,fluxVecNew,resVecNew,fNew,feasible,err,message)
- ! USE eval8summa_module,only:eval8summa                      ! simulation of fluxes and residuals given a trial state vector
- ! implicit none
- ! ! input
- ! real(rkind),intent(in)         :: stateVecNew(:)           ! updated state vector
- ! ! output
- ! real(rkind),intent(out)        :: fluxVecNew(:)            ! updated flux vector
- ! real(qp),intent(out)           :: resVecNew(:) ! NOTE: qp  ! updated residual vector
- ! real(rkind),intent(out)        :: fNew                     ! new function value
- ! logical(lgt),intent(out)       :: feasible                 ! flag to denote the feasibility of the solution
- ! integer(i4b),intent(out)       :: err                      ! error code
- ! character(*),intent(out)       :: message                  ! error message
- ! ! ----------------------------------------------------------------------------------------------------------
- ! ! local
- ! real(rkind),allocatable        :: fRHS(:)                  ! RHS function for ARKODE
- ! character(len=256)             :: cmessage                 ! error message of downwind routine
- ! ! ----------------------------------------------------------------------------------------------------------
- ! ! initialize error control
- ! err=0; message='eval8summa_wrapper/'
-
- ! associate(&
- !  dt_cur         => in_SS4HG % dt_cur         ,& ! intent(in): current stepsize
- !  dt             => in_SS4HG % dt             ,& ! intent(in): entire time step for drainage pond rate
- !  nSnow          => in_SS4HG % nSnow          ,& ! intent(in): number of snow layers
- !  nSoil          => in_SS4HG % nSoil          ,& ! intent(in): number of soil layers
- !  nLayers        => in_SS4HG % nLayers        ,& ! intent(in): total number of layers
- !  nState         => in_SS4HG % nState         ,& ! intent(in): total number of state variables
- !  firstSubStep   => in_SS4HG % firstSubStep   ,& ! intent(in): flag to indicate if we are processing the first sub-step
- !  computeVegFlux => in_SS4HG % computeVegFlux ,& ! intent(in): flag to indicate if computing fluxes over vegetation
- !  scalarSolution => in_SS4HG % scalarSolution ,& ! intent(in): flag to denote if implementing the scalar solution
- !  firstFluxCall  => io_SS4HG % firstFluxCall  ,& ! intent(inout): flag to indicate if we are processing the first flux call  
- !  ixSaturation   => io_SS4HG % ixSaturation    & ! intent(inout): index of the lowest saturated layer (NOTE: only computed on the first iteration)    
- ! &)
- ! ! compute the flux and the residual vector for a given state vector
- !  call eval8summa(&
- !                  ! input: model control
- !                  dt_cur,                  & ! intent(in):    current stepsize
- !                  dt,                      & ! intent(in):    length of the time step (seconds)
- !                  nSnow,                   & ! intent(in):    number of snow layers
- !                  nSoil,                   & ! intent(in):    number of soil layers
- !                  nLayers,                 & ! intent(in):    total number of layers
- !                  nState,                  & ! intent(in):    total number of state variables
- !                  .false.,                 & ! intent(in):    not inside Sundials solver
- !                  firstSubStep,            & ! intent(in):    flag to indicate if we are processing the first sub-step
- !                  firstFluxCall,           & ! intent(inout): flag to indicate if we are processing the first flux call
- !                  .false.,                 & ! intent(in):    not processing the first iteration in a splitting operation
- !                  computeVegFlux,          & ! intent(in):    flag to indicate if we need to compute fluxes over vegetation
- !                  scalarSolution,          & ! intent(in):    flag to indicate the scalar solution
- !                  ! input: state vectors
- !                  stateVecNew,             & ! intent(in):    updated model state vector
- !                  fScale,                  & ! intent(in):    characteristic scale of the function evaluations
- !                  sMul,                    & ! intent(inout): state vector multiplier (used in the residual calculations)
- !                  ! input: data structures
- !                  model_decisions,         & ! intent(in):    model decisions
- !                  lookup_data,             & ! intent(in):    lookup tables
- !                  type_data,               & ! intent(in):    type of vegetation and soil
- !                  attr_data,               & ! intent(in):    spatial attributes
- !                  mpar_data,               & ! intent(in):    model parameters
- !                  forc_data,               & ! intent(in):    model forcing data
- !                  bvar_data,               & ! intent(in):    average model variables for the entire basin
- !                  prog_data,               & ! intent(in):    model prognostic variables for a local HRU
- !                  ! input-output: data structures
- !                  indx_data,               & ! intent(inout): index data
- !                  diag_data,               & ! intent(inout): model diagnostic variables for a local HRU
- !                  flux_data,               & ! intent(inout): model fluxes for a local HRU
- !                  deriv_data,              & ! intent(inout): derivatives in model fluxes w.r.t. relevant state variables
- !                  ! input-output: baseflow
- !                  ixSaturation,            & ! intent(inout): index of the lowest saturated layer (NOTE: only computed on the first iteration)
- !                  dBaseflow_dMatric,       & ! intent(out):   derivative in baseflow w.r.t. matric head (s-1)
- !                  ! output
- !                  feasible,                & ! intent(out):   flag to denote the feasibility of the solution
- !                  fluxVecNew,              & ! intent(out):   new flux vector
- !                  fRHS,                    & ! intent(out):   RHS function for ARKODE
- !                  resSinkNew,              & ! intent(out):   additional (sink) terms on the RHS of the state equation
- !                  resVecNew,               & ! intent(out):   new residual vector
- !                  fNew,                    & ! intent(out):   new function evaluation
- !                  err,cmessage)              ! intent(out):   error control
- ! end associate
-
- ! if(err/=0)then; message=trim(message)//trim(cmessage); return; end if  ! (check for errors)
- ! 
- ! end subroutine eval8summa_wrapper
 
  end subroutine summaSolve4homegrown
 


### PR DESCRIPTION
Hi @ashleymedin - This PR changes the `getBrackets` and `eval8summa_wrapper` routines in `summaSolve4homegrown_module` from internal procedures to module procedures. Structurally, `getBrackets` and `eval8summa_wrapper` have been moved out of the contains block for `summaSolve4homegrown`. This allows access to these procedures outside of `summaSolve4homegrown` (including other modules).

The motivation for these changes is for access to the nested Newton solver (which is under development and may be included in a future PR) and to avoid divergence of our working branches. Essentially, the nested Newton solver needs access to the Newton step refinement tools of the homegrown solver (then we can isolate the impact of nested iterations when comparing both solvers). A separate PR will be made to enable access the remaining homegrown Newton step refinement tools (e.g., line search).

The trade-off for accessibility is longer call syntax for `getBrackets` and `eval8summa_wrapper` (my apologies for that). However, this version of `summaSolver4homegrown_module` is functionally equivalent to the previous version. Test suite output and resource use was not changed.

Thanks for handling all these PRs!



Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] Closes #xxx (identify the issue associated with this PR)
- [x] Code passes standard test cases (results are either bit-for-bit identical, or differences are explained in the PR comment)
- [ ] New tests added (describe which tests were performed to test the changes)
- [ ] Science test figures (add figures to PR comment and describe the tests)
- [ ] Checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] Describe the change in the release notes (use  `./summa/docs/whats-new.md`)