### PR TITLE
Making `refine_Newton_step` in `summaSolve4homegrown_module` externally accessible

### DIFF
--- a/build/source/engine/summaSolve4homegrown.f90
+++ b/build/source/engine/summaSolve4homegrown.f90
@@ -94,8 +94,9 @@ USE mDecisions_module,only:       &
 
 implicit none
 private
-public::summaSolve4homegrown
-public::checkConv
+public :: summaSolve4homegrown
+public :: refine_Newton_step
+public :: checkConv
 contains
 
  ! **************************************************************************************************************************
@@ -135,7 +136,6 @@ contains
                        resVecNew,               & ! intent(out):   new residual vector
                        out_SS4HG)                 ! intent(out):   new function evaluation, convergence flag, and error control  
  USE computJacob_module, only: computJacob
- USE eval8summa_module,  only: imposeConstraints
  USE matrixOper_module,  only: lapackSolv
  USE matrixOper_module,  only: scaleMatrices
  implicit none
@@ -182,11 +182,6 @@ contains
  ! solution/step vectors
  real(rkind),dimension(in_SS4HG % nState) :: rVecScaled           ! residual vector (scaled)
  real(rkind),dimension(in_SS4HG % nState) :: newtStepScaled       ! full newton step (scaled)
- ! step size refinement
- logical(lgt)                    :: doRefine                      ! flag for step refinement
- integer(i4b),parameter          :: ixLineSearch=1001             ! step refinement = line search
- integer(i4b),parameter          :: ixTrustRegion=1002            ! step refinement = trust region
- integer(i4b),parameter          :: ixStepRefinement=ixLineSearch ! decision for the numerical solution
  ! general
  integer(i4b)                    :: mSoil                         ! number of soil layers in solution vector
  integer(i4b)                    :: iLayer                        ! row index
@@ -194,13 +189,8 @@ contains
  logical(lgt)                    :: return_flag                   ! flag that controls execution of return statements
  character(LEN=256)              :: cmessage                      ! error message of downwind routine
  ! class objects for subroutine arguments
- type(in_type_computJacob)           :: in_computJacob  ! computJacob
- type(out_type_computJacob)          :: out_computJacob ! computJacob 
- type(in_type_lineSearchRefinement)  :: in_LSR          ! lineSearchRefinement
- type(out_type_lineSearchRefinement) :: out_LSR         ! lineSearchRefinement 
- type(in_type_lineSearchRefinement)  :: in_TRR          ! trustRegionRefinement
- type(out_type_lineSearchRefinement) :: out_TRR         ! trustRegionRefinement
- type(out_type_lineSearchRefinement) :: out_SRF         ! safeRootFinder
+ type(in_type_computJacob)       :: in_computJacob                ! computJacob object
+ type(out_type_computJacob)      :: out_computJacob               ! computJacob object 
  ! --------------------------------------------------------------------------------------------------------------------------------
  ! --------------------------------------------------------------------------------------------------------------------------------
 
@@ -250,7 +240,12 @@ contains
    ! *** Update steps for the summaSolve4homegrown algorithm (computing the Newton step) ***
    call solve_linear_system;             if (return_flag) return ! solve the linear system for the Newton step -- return if error
   
-   call refine_Newton_step;              if (return_flag) return ! refine Newton step if needed -- return if error
+   ! refine Newton step if needed
+   call refine_Newton_step(in_SS4HG,mSoil,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,fScale,xScale,&         ! input
+                          &model_decisions,lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,& ! input
+                          &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&                ! input-output
+                          &stateVecNew,fluxVecNew,resSinkNew,resVecNew,out_SS4HG)                                    ! output
+   if (return_flag) return ! return if error
   end subroutine update_summaSolve4homegrown
 
   subroutine finalize_summaSolve4homegrown
@@ -318,66 +313,6 @@ contains
    end associate
   end subroutine solve_linear_system
 
-  subroutine refine_Newton_step  
-   ! *** Refine the Newton step if necessary ***  
-  
-   ! initialize the flag for step refinement
-   doRefine=.true.
-  
-   ! * case 1: state vector
-   ! compute the flux vector and the residual, and (if necessary) refine the iteration increment
-   ! NOTE: in 99.9% of cases newtStep will be used (no refinement)
-
-   associate(&
-    fOld      => in_SS4HG  % fOld     ,&
-    fnew      => out_SS4HG % fnew     ,& 
-    converged => out_SS4HG % converged,&
-    err       => out_SS4HG % err      ,& 
-    message   => out_SS4HG % message   &     
-   &)  
-    if (size(stateVecTrial)>1) then
-
-     ! try to backtrack
-     select case(ixStepRefinement)
-      case(ixLineSearch)  
-       call in_LSR % initialize(doRefine,fOld)    
-       call lineSearchRefinement(in_LSR,in_SS4HG,mSoil,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,fScale,xScale,&
-                                &model_decisions,lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
-                                &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
-                                &stateVecNew,fluxVecNew,resSinkNew,resVecNew,out_SS4HG,out_LSR)
-       call out_LSR % finalize(fNew,converged,err,cmessage)
-      case(ixTrustRegion)
-       call in_TRR % initialize(doRefine,fOld)
-       call trustRegionRefinement(in_TRR,in_SS4HG,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,stateVecNew,fluxVecNew,resVecNew,out_TRR)
-       call out_TRR % finalize(fNew,converged,err,cmessage)
-      case default; err=20; message=trim(message)//'unable to identify numerical solution'; return_flag=.true.; return
-     end select
-  
-     ! check warnings: negative error code = warning; in this case back-tracked to the original value
-     ! NOTE: Accept the full newton step if back-tracked to the original value
-     if (err<0) then
-      doRefine=.false.;
-      call in_LSR % initialize(doRefine,fOld)    
-      call lineSearchRefinement(in_LSR,in_SS4HG,mSoil,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,fScale,xScale,&
-                               &model_decisions,lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
-                               &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
-                               &stateVecNew,fluxVecNew,resSinkNew,resVecNew,out_SS4HG,out_LSR)
-      call out_LSR % finalize(fNew,converged,err,cmessage)
-     end if
-  
-    ! * case 2: scalar
-    else
-     call safeRootfinder(mSoil,stateVecTrial,rVecScaled,newtStepScaled,fScale,xScale,&
-                        &in_SS4HG,model_decisions,lookup_data,type_data,attr_data,&
-                        &mpar_data,forc_data,bvar_data,prog_data,&
-                        &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
-                        &out_SS4HG,stateVecNew,fluxVecNew,resSinkNew,resVecNew,out_SRF)
-     call out_SRF % finalize(fNew,converged,err,cmessage)
-     if (err/=0) then; message=trim(message)//trim(cmessage); return_flag=.true.; return; end if  ! check for errors
-    end if
-   end associate
-  end subroutine refine_Newton_step  
-
   subroutine initialize_computJacob_summaSolve4homegrown
    ! *** Transfer data to in_computJacob class object from local variables in summaSolve4homegrown ***
    associate(&
@@ -401,6 +336,118 @@ contains
   end subroutine finalize_computJacob_summaSolve4homegrown
 
  end subroutine summaSolve4homegrown
+
+ ! *********************************************************************************************************
+ ! * module subroutine refine_Newton_step: refine the Newton step if necessary
+ ! *********************************************************************************************************
+ subroutine refine_Newton_step(in_SS4HG,mSoil,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,fScale,xScale,&         ! input
+                              &model_decisions,lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,& ! input
+                              &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&                ! input-output
+                              &stateVecNew,fluxVecNew,resSinkNew,resVecNew,out_SS4HG)                                    ! output
+  ! provide access to the external procedures
+  USE matrixOper_module, only: computeGradient
+  USE eval8summa_module, only: imposeConstraints
+  implicit none
+  ! input
+  type(in_type_summaSolve4homegrown),intent(in) :: in_SS4HG    ! model control variables and previous function evaluation
+  integer(i4b),intent(in)         :: mSoil                     ! number of soil layers in solution vector
+  real(rkind),intent(in)          :: stateVecTrial(:)          ! trial state vector
+  real(rkind),intent(in)          :: newtStepScaled(:)         ! scaled newton step
+  real(rkind),intent(in)          :: aJacScaled(:,:)           ! scaled jacobian matrix
+  real(rkind),intent(in)          :: rVecScaled(:)             ! scaled residual vector
+  real(rkind),intent(in)          :: fScale(:)                 ! characteristic scale of the function evaluations
+  real(rkind),intent(in)          :: xScale(:)                 ! characteristic scale of the state vector
+  type(model_options),intent(in)  :: model_decisions(:)        ! model decisions
+  type(zLookup),      intent(in)  :: lookup_data               ! lookup tables
+  type(var_i),        intent(in)  :: type_data                 ! type of vegetation and soil
+  type(var_d),        intent(in)  :: attr_data                 ! spatial attributes
+  type(var_dlength),  intent(in)  :: mpar_data                 ! model parameters
+  type(var_d),        intent(in)  :: forc_data                 ! model forcing data
+  type(var_dlength),  intent(in)  :: bvar_data                 ! model variables for the local basin
+  type(var_dlength),  intent(in)  :: prog_data                 ! prognostic variables for a local HRU
+  ! input-output
+  real(qp),intent(inout)          :: sMul(:)   ! NOTE: qp      ! state vector multiplier (used in the residual calculations)
+  type(io_type_summaSolve4homegrown),intent(inout) :: io_SS4HG ! first flux call flag and baseflow variables
+  type(var_ilength),intent(inout) :: indx_data                 ! indices defining model states and layers
+  type(var_dlength),intent(inout) :: diag_data                 ! diagnostic variables for a local HRU
+  type(var_dlength),intent(inout) :: flux_data                 ! model fluxes for a local HRU
+  type(var_dlength),intent(inout) :: deriv_data                ! derivatives in model fluxes w.r.t. relevant state variables
+  real(rkind),intent(inout)       :: dBaseflow_dMatric(:,:)    ! derivative in baseflow w.r.t. matric head (s-1)
+  ! output
+  real(rkind),intent(out)         :: stateVecNew(:)            ! new state vector
+  real(rkind),intent(out)         :: fluxVecNew(:)             ! new flux vector
+  real(rkind),intent(out)         :: resSinkNew(:)             ! sink terms on the RHS of the flux equation
+  real(qp),intent(out)            :: resVecNew(:) ! NOTE: qp   ! new residual vector
+  type(out_type_summaSolve4homegrown),intent(out) :: out_SS4HG ! new function evaluation, convergence flag, and error control
+  ! local
+  logical(lgt)                    :: doRefine                      ! flag for step refinement
+  integer(i4b),parameter          :: ixLineSearch=1001             ! step refinement = line search
+  integer(i4b),parameter          :: ixTrustRegion=1002            ! step refinement = trust region
+  integer(i4b),parameter          :: ixStepRefinement=ixLineSearch ! decision for the numerical solution
+  logical(lgt)                    :: return_flag                   ! flag that controls execution of return statements
+  character(LEN=256)              :: cmessage                      ! error message of downwind routine
+  type(in_type_lineSearchRefinement)  :: in_LSR                    ! lineSearchRefinement
+  type(out_type_lineSearchRefinement) :: out_LSR                   ! lineSearchRefinement 
+  type(in_type_lineSearchRefinement)  :: in_TRR                    ! trustRegionRefinement
+  type(out_type_lineSearchRefinement) :: out_TRR                   ! trustRegionRefinement
+  type(out_type_lineSearchRefinement) :: out_SRF                   ! safeRootFinder
+ 
+  ! initialize the flag for step refinement
+  doRefine=.true.
+ 
+  ! * case 1: state vector
+  ! compute the flux vector and the residual, and (if necessary) refine the iteration increment
+  ! NOTE: in 99.9% of cases newtStep will be used (no refinement)
+
+  associate(&
+   fOld      => in_SS4HG  % fOld     ,&
+   fnew      => out_SS4HG % fnew     ,& 
+   converged => out_SS4HG % converged,&
+   err       => out_SS4HG % err      ,& 
+   message   => out_SS4HG % message   &     
+  &)  
+   if (size(stateVecTrial)>1) then
+
+    ! try to backtrack
+    select case(ixStepRefinement)
+     case(ixLineSearch)  
+      call in_LSR % initialize(doRefine,fOld)    
+      call lineSearchRefinement(in_LSR,in_SS4HG,mSoil,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,fScale,xScale,&  ! input
+                               &model_decisions,lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,& ! input
+                               &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&                ! input-output
+                               &stateVecNew,fluxVecNew,resSinkNew,resVecNew,out_SS4HG,out_LSR)                            ! output
+      call out_LSR % finalize(fNew,converged,err,cmessage)
+     case(ixTrustRegion)
+      call in_TRR % initialize(doRefine,fOld)
+      call trustRegionRefinement(in_TRR,in_SS4HG,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,stateVecNew,fluxVecNew,resVecNew,out_TRR)
+      call out_TRR % finalize(fNew,converged,err,cmessage)
+     case default; err=20; message=trim(message)//'unable to identify numerical solution'; return_flag=.true.; return
+    end select
+ 
+    ! check warnings: negative error code = warning; in this case back-tracked to the original value
+    ! NOTE: Accept the full newton step if back-tracked to the original value
+    if (err<0) then
+     doRefine=.false.;
+     call in_LSR % initialize(doRefine,fOld)    
+     call lineSearchRefinement(in_LSR,in_SS4HG,mSoil,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,fScale,xScale,&  ! input
+                              &model_decisions,lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,& ! input
+                              &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&                ! input-output
+                              &stateVecNew,fluxVecNew,resSinkNew,resVecNew,out_SS4HG,out_LSR)                            ! output
+     call out_LSR % finalize(fNew,converged,err,cmessage)
+    end if
+ 
+   ! * case 2: scalar
+   else
+    call safeRootfinder(mSoil,stateVecTrial,rVecScaled,newtStepScaled,fScale,xScale,&              ! input
+                       &in_SS4HG,model_decisions,lookup_data,type_data,attr_data,&                 ! input
+                       &mpar_data,forc_data,bvar_data,prog_data,&                                  ! input
+                       &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,& ! input-output
+                       &out_SS4HG,stateVecNew,fluxVecNew,resSinkNew,resVecNew,out_SRF)             ! output
+    call out_SRF % finalize(fNew,converged,err,cmessage)
+    if (err/=0) then; message=trim(message)//trim(cmessage); return_flag=.true.; return; end if  ! check for errors
+   end if
+  end associate
+ end subroutine refine_Newton_step  
 
  ! *********************************************************************************************************
  ! * module subroutine lineSearchRefinement: refine the iteration increment using line searches
@@ -617,17 +664,17 @@ contains
   USE matrixOper_module, only: computeGradient
   implicit none
   ! input
-  type(in_type_lineSearchRefinement),intent(in) :: in_TRR            ! object for scalar intent(in) arguments -- reusing line search class
-  type(in_type_summaSolve4homegrown),intent(in) :: in_SS4HG          ! model control variables and previous function evaluation
-  real(rkind),intent(in)                        :: stateVecTrial(:)  ! trial state vector
-  real(rkind),intent(in)                        :: newtStepScaled(:) ! scaled newton step
-  real(rkind),intent(in)                        :: aJacScaled(:,:)   ! scaled jacobian matrix
-  real(rkind),intent(in)                        :: rVecScaled(:)     ! scaled residual vector
+  type(in_type_lineSearchRefinement),intent(in)   :: in_TRR            ! object for scalar intent(in) arguments -- reusing line search class
+  type(in_type_summaSolve4homegrown),intent(in)   :: in_SS4HG          ! model control variables and previous function evaluation
+  real(rkind),intent(in)                          :: stateVecTrial(:)  ! trial state vector
+  real(rkind),intent(in)                          :: newtStepScaled(:) ! scaled newton step
+  real(rkind),intent(in)                          :: aJacScaled(:,:)   ! scaled jacobian matrix
+  real(rkind),intent(in)                          :: rVecScaled(:)     ! scaled residual vector
   ! output
-  real(rkind),intent(out)                       :: stateVecNew(:)    ! new state vector
-  real(rkind),intent(out)                       :: fluxVecNew(:)     ! new flux vector
-  real(qp),intent(out)                          :: resVecNew(:)      ! NOTE: qp  ! new residual vector
-  type(out_type_lineSearchRefinement)           :: out_TRR           ! object for scalar intent(in) arguments -- reusing line search class
+  real(rkind),intent(out)                         :: stateVecNew(:)    ! new state vector
+  real(rkind),intent(out)                         :: fluxVecNew(:)     ! new flux vector
+  real(qp),intent(out)                            :: resVecNew(:)      ! NOTE: qp  ! new residual vector
+  type(out_type_lineSearchRefinement),intent(out) :: out_TRR           ! object for scalar intent(in) arguments -- reusing line search class
   ! --------------------------------------------------------------------------------------------------------
   ! local variables
 

--- a/build/source/engine/summaSolve4homegrown.f90
+++ b/build/source/engine/summaSolve4homegrown.f90
@@ -102,12 +102,10 @@ contains
  ! public subroutine summaSolve4homegrown: calculate the iteration increment, evaluate the new state, and refine if necessary
  ! **************************************************************************************************************************
  subroutine summaSolve4homegrown(&
-                        in_SS4HG,               & ! intent(in): model control and previous function value
                        ! input: model control
-                       !firstFluxCall,           & ! intent(inout): flag to indicate if we are processing the first flux call
+                       in_SS4HG,                & ! intent(in): model control and previous function value
                        ! input: state vectors
                        stateVecTrial,           & ! intent(in):    trial state vector
-                       !xMin,xMax,               & ! intent(inout): brackets of the root
                        fScale,                  & ! intent(in):    characteristic scale of the function evaluations
                        xScale,                  & ! intent(in):    characteristic scale of the state vector
                        rVec,                    & ! intent(in):    residual vector
@@ -128,7 +126,6 @@ contains
                        flux_data,               & ! intent(inout): model fluxes for a local HRU
                        deriv_data,              & ! intent(inout): derivatives in model fluxes w.r.t. relevant state variables
                        ! input-output: baseflow
-                       !ixSaturation,            & ! intent(inout): index of the lowest saturated layer (NOTE: only computed on the first iteration)
                        dBaseflow_dMatric,       & ! intent(inout): derivative in baseflow w.r.t. matric head (s-1)
                        io_SS4HG,                & ! intent(inout): first flux call flag, root brackets, index of lowest saturated layer
                        ! output
@@ -143,71 +140,67 @@ contains
  USE matrixOper_module,  only: scaleMatrices
  implicit none
  ! --------------------------------------------------------------------------------------------------------------------------------
- type(in_type_summaSolve4homegrown),intent(in)     :: in_SS4HG  ! model control variables and previous function evaluation
- type(io_type_summaSolve4homegrown),intent(inout)  :: io_SS4HG  ! first flux call flag and baseflow variables
- ! input: model control
-! logical(lgt),intent(inout)      :: firstFluxCall            ! flag to indicate if we are processing the first flux call
+ type(in_type_summaSolve4homegrown),intent(in)    :: in_SS4HG ! model control variables and previous function evaluation
+ type(io_type_summaSolve4homegrown),intent(inout) :: io_SS4HG ! first flux call flag and baseflow variables
  ! input: state vectors
- real(rkind),intent(in)          :: stateVecTrial(:)         ! trial state vector
-! real(rkind),intent(inout)       :: xMin,xMax                ! brackets of the root
- real(rkind),intent(in)          :: fScale(:)                ! characteristic scale of the function evaluations
- real(rkind),intent(in)          :: xScale(:)                ! characteristic scale of the state vector
- real(qp),intent(in)             :: rVec(:)   ! NOTE: qp     ! residual vector
- real(qp),intent(inout)          :: sMul(:)   ! NOTE: qp     ! state vector multiplier (used in the residual calculations)
- real(rkind),intent(inout)       :: dMat(:)                  ! diagonal matrix (excludes flux derivatives)
+ real(rkind),intent(in)          :: stateVecTrial(:)          ! trial state vector
+ real(rkind),intent(in)          :: fScale(:)                 ! characteristic scale of the function evaluations
+ real(rkind),intent(in)          :: xScale(:)                 ! characteristic scale of the state vector
+ real(qp),intent(in)             :: rVec(:)   ! NOTE: qp      ! residual vector
+ real(qp),intent(inout)          :: sMul(:)   ! NOTE: qp      ! state vector multiplier (used in the residual calculations)
+ real(rkind),intent(inout)       :: dMat(:)                   ! diagonal matrix (excludes flux derivatives)
  ! input: data structures
- type(model_options),intent(in)  :: model_decisions(:)       ! model decisions
- type(zLookup),      intent(in)  :: lookup_data              ! lookup tables
- type(var_i),        intent(in)  :: type_data                ! type of vegetation and soil
- type(var_d),        intent(in)  :: attr_data                ! spatial attributes
- type(var_dlength),  intent(in)  :: mpar_data                ! model parameters
- type(var_d),        intent(in)  :: forc_data                ! model forcing data
- type(var_dlength),  intent(in)  :: bvar_data                ! model variables for the local basin
- type(var_dlength),  intent(in)  :: prog_data                ! prognostic variables for a local HRU
+ type(model_options),intent(in)  :: model_decisions(:)        ! model decisions
+ type(zLookup),      intent(in)  :: lookup_data               ! lookup tables
+ type(var_i),        intent(in)  :: type_data                 ! type of vegetation and soil
+ type(var_d),        intent(in)  :: attr_data                 ! spatial attributes
+ type(var_dlength),  intent(in)  :: mpar_data                 ! model parameters
+ type(var_d),        intent(in)  :: forc_data                 ! model forcing data
+ type(var_dlength),  intent(in)  :: bvar_data                 ! model variables for the local basin
+ type(var_dlength),  intent(in)  :: prog_data                 ! prognostic variables for a local HRU
  ! output: data structures
- type(var_ilength),intent(inout) :: indx_data                ! indices defining model states and layers
- type(var_dlength),intent(inout) :: diag_data                ! diagnostic variables for a local HRU
- type(var_dlength),intent(inout) :: flux_data                ! model fluxes for a local HRU
- type(var_dlength),intent(inout) :: deriv_data               ! derivatives in model fluxes w.r.t. relevant state variables
+ type(var_ilength),intent(inout) :: indx_data                 ! indices defining model states and layers
+ type(var_dlength),intent(inout) :: diag_data                 ! diagnostic variables for a local HRU
+ type(var_dlength),intent(inout) :: flux_data                 ! model fluxes for a local HRU
+ type(var_dlength),intent(inout) :: deriv_data                ! derivatives in model fluxes w.r.t. relevant state variables
  ! input-output: baseflow
-! integer(i4b),intent(inout)      :: ixSaturation             ! index of the lowest saturated layer (NOTE: only computed on the first iteration)
- real(rkind),intent(inout)       :: dBaseflow_dMatric(:,:)   ! derivative in baseflow w.r.t. matric head (s-1)
+ real(rkind),intent(inout)       :: dBaseflow_dMatric(:,:)    ! derivative in baseflow w.r.t. matric head (s-1)
  ! output: flux and residual vectors
- real(rkind),intent(out)         :: stateVecNew(:)           ! new state vector
- real(rkind),intent(out)         :: fluxVecNew(:)            ! new flux vector
- real(rkind),intent(out)         :: resSinkNew(:)            ! sink terms on the RHS of the flux equation
- real(qp),intent(out)            :: resVecNew(:) ! NOTE: qp  ! new residual vector
- type(out_type_summaSolve4homegrown),intent(out)  :: out_SS4HG  ! new function evaluation, convergence flag, and error control
+ real(rkind),intent(out)         :: stateVecNew(:)            ! new state vector
+ real(rkind),intent(out)         :: fluxVecNew(:)             ! new flux vector
+ real(rkind),intent(out)         :: resSinkNew(:)             ! sink terms on the RHS of the flux equation
+ real(qp),intent(out)            :: resVecNew(:) ! NOTE: qp   ! new residual vector
+ type(out_type_summaSolve4homegrown),intent(out) :: out_SS4HG ! new function evaluation, convergence flag, and error control
  ! --------------------------------------------------------------------------------------------------------------------------------
  ! local variables
  ! --------------------------------------------------------------------------------------------------------------------------------
  ! Jacobian matrix
- real(rkind)                     :: nJac(in_SS4HG % nState,in_SS4HG % nState)      ! numerical Jacobian matrix
- real(rkind)                     :: aJac(in_SS4HG % nLeadDim,in_SS4HG % nState)      ! Jacobian matrix
- real(rkind)                     :: aJacScaled(in_SS4HG % nLeadDim,in_SS4HG % nState)      ! Jacobian matrix (scaled)
- real(rkind)                     :: aJacScaledTemp(in_SS4HG % nLeadDim,in_SS4HG % nState)  ! Jacobian matrix (scaled) -- temporary copy since decomposed in lapack
+ real(rkind) :: nJac(in_SS4HG % nState,in_SS4HG % nState)             ! numerical Jacobian matrix
+ real(rkind) :: aJac(in_SS4HG % nLeadDim,in_SS4HG % nState)           ! Jacobian matrix
+ real(rkind) :: aJacScaled(in_SS4HG % nLeadDim,in_SS4HG % nState)     ! Jacobian matrix (scaled)
+ real(rkind) :: aJacScaledTemp(in_SS4HG % nLeadDim,in_SS4HG % nState) ! Jacobian matrix (scaled) -- temporary copy since decomposed in lapack
  ! solution/step vectors
- real(rkind),dimension(in_SS4HG % nState)   :: rVecScaled               ! residual vector (scaled)
- real(rkind),dimension(in_SS4HG % nState)   :: newtStepScaled           ! full newton step (scaled)
+ real(rkind),dimension(in_SS4HG % nState) :: rVecScaled           ! residual vector (scaled)
+ real(rkind),dimension(in_SS4HG % nState) :: newtStepScaled       ! full newton step (scaled)
  ! step size refinement
- logical(lgt)                    :: doRefine                 ! flag for step refinement
- integer(i4b),parameter          :: ixLineSearch=1001        ! step refinement = line search
- integer(i4b),parameter          :: ixTrustRegion=1002       ! step refinement = trust region
- integer(i4b),parameter          :: ixStepRefinement=ixLineSearch   ! decision for the numerical solution
+ logical(lgt)                    :: doRefine                      ! flag for step refinement
+ integer(i4b),parameter          :: ixLineSearch=1001             ! step refinement = line search
+ integer(i4b),parameter          :: ixTrustRegion=1002            ! step refinement = trust region
+ integer(i4b),parameter          :: ixStepRefinement=ixLineSearch ! decision for the numerical solution
  ! general
- integer(i4b)                    :: mSoil                    ! number of soil layers in solution vector
- integer(i4b)                    :: iLayer                   ! row index
- integer(i4b)                    :: jLayer                   ! column index
- logical(lgt)                    :: return_flag              ! flag that controls execution of return statements
- character(LEN=256)              :: cmessage                 ! error message of downwind routine
+ integer(i4b)                    :: mSoil                         ! number of soil layers in solution vector
+ integer(i4b)                    :: iLayer                        ! row index
+ integer(i4b)                    :: jLayer                        ! column index
+ logical(lgt)                    :: return_flag                   ! flag that controls execution of return statements
+ character(LEN=256)              :: cmessage                      ! error message of downwind routine
  ! class objects for subroutine arguments
  type(in_type_computJacob)           :: in_computJacob  ! computJacob
  type(out_type_computJacob)          :: out_computJacob ! computJacob 
- type(in_type_lineSearchRefinement)  :: in_LSR  ! lineSearchRefinement
- type(out_type_lineSearchRefinement) :: out_LSR ! lineSearchRefinement 
- type(in_type_lineSearchRefinement)  :: in_TRR  ! trustRegionRefinement
- type(out_type_lineSearchRefinement) :: out_TRR ! trustRegionRefinement
- type(out_type_lineSearchRefinement) :: out_SRF ! safeRootFinder
+ type(in_type_lineSearchRefinement)  :: in_LSR          ! lineSearchRefinement
+ type(out_type_lineSearchRefinement) :: out_LSR         ! lineSearchRefinement 
+ type(in_type_lineSearchRefinement)  :: in_TRR          ! trustRegionRefinement
+ type(out_type_lineSearchRefinement) :: out_TRR         ! trustRegionRefinement
+ type(out_type_lineSearchRefinement) :: out_SRF         ! safeRootFinder
  ! --------------------------------------------------------------------------------------------------------------------------------
  ! --------------------------------------------------------------------------------------------------------------------------------
 

--- a/build/source/engine/summaSolve4homegrown.f90
+++ b/build/source/engine/summaSolve4homegrown.f90
@@ -341,7 +341,10 @@ contains
      select case(ixStepRefinement)
       case(ixLineSearch)  
        call in_LSR % initialize(doRefine,fOld)    
-       call lineSearchRefinement(in_LSR,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,stateVecNew,fluxVecNew,resVecNew,out_LSR)
+       call lineSearchRefinement(in_LSR,in_SS4HG,mSoil,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,fScale,xScale,&
+                                &model_decisions,lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
+                                &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
+                                &stateVecNew,fluxVecNew,resSinkNew,resVecNew,out_SS4HG,out_LSR)
        call out_LSR % finalize(fNew,converged,err,cmessage)
       case(ixTrustRegion)
        call in_TRR % initialize(doRefine,fOld)
@@ -355,7 +358,10 @@ contains
      if (err<0) then
       doRefine=.false.;
       call in_LSR % initialize(doRefine,fOld)    
-      call lineSearchRefinement(in_LSR,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,stateVecNew,fluxVecNew,resVecNew,out_LSR)
+      call lineSearchRefinement(in_LSR,in_SS4HG,mSoil,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,fScale,xScale,&
+                               &model_decisions,lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
+                               &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
+                               &stateVecNew,fluxVecNew,resSinkNew,resVecNew,out_SS4HG,out_LSR)
       call out_LSR % finalize(fNew,converged,err,cmessage)
      end if
   
@@ -394,25 +400,52 @@ contains
    end associate 
   end subroutine finalize_computJacob_summaSolve4homegrown
 
+ end subroutine summaSolve4homegrown
 
-  ! *********************************************************************************************************
-  ! * internal subroutine lineSearchRefinement: refine the iteration increment using line searches
-  ! *********************************************************************************************************
-  subroutine lineSearchRefinement(in_LSR,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,stateVecNew,fluxVecNew,resVecNew,out_LSR)
-  ! provide access to the matrix routines
+ ! *********************************************************************************************************
+ ! * module subroutine lineSearchRefinement: refine the iteration increment using line searches
+ ! *********************************************************************************************************
+ subroutine lineSearchRefinement(in_LSR,in_SS4HG,mSoil,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,fScale,xScale,&
+                                &model_decisions,lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
+                                &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
+                                &stateVecNew,fluxVecNew,resSinkNew,resVecNew,out_SS4HG,out_LSR)
+  ! provide access to the external procedures
   USE matrixOper_module, only: computeGradient
+  USE eval8summa_module, only: imposeConstraints
   implicit none
   ! input
-  type(in_type_lineSearchRefinement),intent(in)  :: in_LSR   ! class object for intent(in) arguments
-  real(rkind),intent(in)         :: stateVecTrial(:)         ! trial state vector
-  real(rkind),intent(in)         :: newtStepScaled(:)        ! scaled newton step
-  real(rkind),intent(in)         :: aJacScaled(:,:)          ! scaled jacobian matrix
-  real(rkind),intent(in)         :: rVecScaled(:)            ! scaled residual vector
+  type(in_type_lineSearchRefinement),intent(in) :: in_LSR      ! class object for intent(in) arguments
+  type(in_type_summaSolve4homegrown),intent(in) :: in_SS4HG    ! model control variables and previous function evaluation
+  integer(i4b),intent(in)         :: mSoil                     ! number of soil layers in solution vector
+  real(rkind),intent(in)          :: stateVecTrial(:)          ! trial state vector
+  real(rkind),intent(in)          :: newtStepScaled(:)         ! scaled newton step
+  real(rkind),intent(in)          :: aJacScaled(:,:)           ! scaled jacobian matrix
+  real(rkind),intent(in)          :: rVecScaled(:)             ! scaled residual vector
+  real(rkind),intent(in)          :: fScale(:)                 ! characteristic scale of the function evaluations
+  real(rkind),intent(in)          :: xScale(:)                 ! characteristic scale of the state vector
+  type(model_options),intent(in)  :: model_decisions(:)        ! model decisions
+  type(zLookup),      intent(in)  :: lookup_data               ! lookup tables
+  type(var_i),        intent(in)  :: type_data                 ! type of vegetation and soil
+  type(var_d),        intent(in)  :: attr_data                 ! spatial attributes
+  type(var_dlength),  intent(in)  :: mpar_data                 ! model parameters
+  type(var_d),        intent(in)  :: forc_data                 ! model forcing data
+  type(var_dlength),  intent(in)  :: bvar_data                 ! model variables for the local basin
+  type(var_dlength),  intent(in)  :: prog_data                 ! prognostic variables for a local HRU
+  ! input-output
+  real(qp),intent(inout)          :: sMul(:)   ! NOTE: qp      ! state vector multiplier (used in the residual calculations)
+  type(io_type_summaSolve4homegrown),intent(inout) :: io_SS4HG ! first flux call flag and baseflow variables
+  type(var_ilength),intent(inout) :: indx_data                 ! indices defining model states and layers
+  type(var_dlength),intent(inout) :: diag_data                 ! diagnostic variables for a local HRU
+  type(var_dlength),intent(inout) :: flux_data                 ! model fluxes for a local HRU
+  type(var_dlength),intent(inout) :: deriv_data                ! derivatives in model fluxes w.r.t. relevant state variables
+  real(rkind),intent(inout)       :: dBaseflow_dMatric(:,:)    ! derivative in baseflow w.r.t. matric head (s-1)
   ! output
-  real(rkind),intent(out)        :: stateVecNew(:)           ! new state vector
-  real(rkind),intent(out)        :: fluxVecNew(:)            ! new flux vector
-  real(qp),intent(out)           :: resVecNew(:) ! NOTE: qp  ! new residual vector
-  type(out_type_lineSearchRefinement),intent(out) :: out_LSR ! class object for intent(out) arguments
+  real(rkind),intent(out)        :: stateVecNew(:)             ! new state vector
+  real(rkind),intent(out)        :: fluxVecNew(:)              ! new flux vector
+  real(rkind),intent(out)        :: resSinkNew(:)              ! sink terms on the RHS of the flux equation
+  real(qp),intent(out)           :: resVecNew(:) ! NOTE: qp    ! new residual vector
+  type(out_type_summaSolve4homegrown),intent(out) :: out_SS4HG ! new function evaluation, convergence flag, and error control
+  type(out_type_lineSearchRefinement),intent(out) :: out_LSR   ! class object for intent(out) arguments
   ! --------------------------------------------------------------------------------------------------------
   ! local
   character(len=256)             :: cmessage                      ! error message of downwind routine
@@ -448,14 +481,14 @@ contains
   &)
    ! initialize error control
    err=0; message='lineSearchRefinement/'
-   converged =.false.
+   converged = .false.
 
    ! check the need to compute the line search
-   if(doLineSearch)then
+   if (doLineSearch) then
 
     ! compute the gradient of the function vector
     call computeGradient(ixMatrix,nState,aJacScaled,rVecScaled,gradScaled,err,cmessage)
-    if(err/=0)then; message=trim(message)//trim(cmessage); return; end if  ! (check for errors)
+    if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
 
     ! compute the initial slope
     slopeInit = dot_product(gradScaled,newtStepScaled)
@@ -476,7 +509,7 @@ contains
     xInc(:) = xInc(:)*xScale(:)
 
     ! if enthalpy, then need to convert the iteration increment to temperature
-    !if(nrgFormulation==ix_enthalpy) xInc(ixNrgOnly) = xInc(ixNrgOnly)/dMat(ixNrgOnly)
+    !if (nrgFormulation==ix_enthalpy) xInc(ixNrgOnly) = xInc(ixNrgOnly)/dMat(ixNrgOnly)
 
     ! state vector with proposed iteration increment
     stateVecNew = stateVecTrial + xInc
@@ -484,7 +517,7 @@ contains
     ! impose solution constraints adjusting state vector and iteration increment
     ! NOTE: We may not need to do this (or at least, do ALL of this), as we can probably rely on the line search here
     call imposeConstraints(model_decisions,indx_data,prog_data,mpar_data,stateVecNew,stateVecTrial,nState,nSoil,nSnow,cmessage,err)
-    if(err/=0)then; message=trim(message)//trim(cmessage); return; end if  ! (check for errors)
+    if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
     xInc = stateVecNew - stateVecTrial
 
     ! compute the residual vector and function
@@ -493,10 +526,10 @@ contains
                            &lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
                            &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
                            &fluxVecNew,resSinkNew,resVecNew,fNew,feasible,err,cmessage)
-    if(err/=0)then; message=trim(message)//trim(cmessage); return; end if  ! (check for errors)
+    if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
 
     ! check line search
-    if(globalPrintFlag)then
+    if (globalPrintFlag) then
      write(*,'(a,1x,i4,1x,e17.10)' ) 'iLine, xLambda                 = ', iLine, xLambda
      write(*,'(a,1x,10(e17.10,1x))') 'fOld,fNew                      = ', fOld,fNew
      write(*,'(a,1x,10(e17.10,1x))') 'fold + alpha*slopeInit*xLambda = ', fold + alpha*slopeInit*xLambda
@@ -505,33 +538,33 @@ contains
     end if
 
     ! check feasibility
-    if(.not.feasible) cycle ! go back and impose constraints again
+    if (.not.feasible) cycle ! go back and impose constraints again
 
     ! check convergence
     ! NOTE: some efficiency gains possible by scaling the full newton step outside the line search loop
     converged = checkConv(mSoil,in_SS4HG,mpar_data,indx_data,prog_data,resVecNew,newtStepScaled*xScale,stateVecNew,out_SS4HG)
-    if(converged) return
+    if (converged) return
 
     ! early return if not computing the line search
-    if(.not.doLineSearch) return
+    if (.not.doLineSearch) return
 
     ! check if the function is accepted
-    if(fNew < fold + alpha*slopeInit*xLambda) return
+    if (fNew < fold + alpha*slopeInit*xLambda) return
 
     ! ***
     ! *** IF GET TO HERE WE BACKTRACK
     !      --> all remaining code simply computes the restricted step multiplier (xLambda)
 
     ! first backtrack: use quadratic
-    if(iLine==1)then
-     xLambdaTemp = -slopeInit / (2._rkind*(fNew - fOld - slopeInit) )
-     if(xLambdaTemp > 0.5_rkind*xLambda) xLambdaTemp = 0.5_rkind*xLambda
+    if (iLine==1) then
+     xLambdaTemp = -slopeInit / ( 2._rkind*(fNew - fOld - slopeInit) )
+     if (xLambdaTemp > 0.5_rkind*xLambda) xLambdaTemp = 0.5_rkind*xLambda
 
     ! subsequent backtracks: use cubic
     else
 
      ! check that we did not back-track all the way back to the original value
-     if(iLine==maxLineSearch)then
+     if (iLine == maxLineSearch) then
       message=trim(message)//'backtracked all the way back to the original value'
       err=-20; return
      end if
@@ -545,21 +578,21 @@ contains
      bCoef = (-xLambdaPrev*rhs1/(xLambda*xLambda) + xLambda*rhs2/(xLambdaPrev*xLambdaPrev)) / (xLambda - xLambdaPrev)
 
      ! check if a quadratic
-     if(aCoef==0._rkind)then
+     if (aCoef == 0._rkind) then
       xLambdaTemp = -slopeInit/(2._rkind*bCoef)
 
      ! calculate cubic
      else
       disc = bCoef*bCoef - 3._rkind*aCoef*slopeInit
-      if(disc < 0._rkind)then
+      if (disc < 0._rkind) then
        xLambdaTemp = 0.5_rkind*xLambda
       else
        xLambdaTemp = (-bCoef + sqrt(disc))/(3._rkind*aCoef)
       end if
-     end if  ! calculating cubic
+     end if
 
      ! constrain to <= 0.5*xLambda
-     if(xLambdaTemp > 0.5_rkind*xLambda) xLambdaTemp=0.5_rkind*xLambda
+     if (xLambdaTemp > 0.5_rkind*xLambda) xLambdaTemp=0.5_rkind*xLambda
 
     end if  ! subsequent backtracks
 
@@ -570,12 +603,10 @@ contains
     ! constrain lambda
     xLambda = max(xLambdaTemp, 0.1_rkind*xLambda)
 
-   end do lineSearch  ! backtrack loop
+   end do lineSearch
   end associate
 
-  end subroutine lineSearchRefinement
-
- end subroutine summaSolve4homegrown
+ end subroutine lineSearchRefinement
 
  ! *********************************************************************************************************
  ! * module subroutine trustRegionRefinement: refine the iteration increment using trust regions

--- a/build/source/engine/summaSolve4homegrown.f90
+++ b/build/source/engine/summaSolve4homegrown.f90
@@ -578,138 +578,6 @@ contains
  end subroutine summaSolve4homegrown
 
  ! *********************************************************************************************************
- ! module function checkConv: check convergence based on the residual vector
- ! *********************************************************************************************************
- function checkConv(mSoil,in_SS4HG,mpar_data,indx_data,prog_data,rVec,xInc,xVec,out_SS4HG)
-  implicit none
-  ! result
-  logical(lgt)                 :: checkConv                    ! flag to denote convergence
-  ! dummies
-  integer(i4b),intent(in)      :: mSoil                        ! number of soil layers in solution vector
-  type(in_type_summaSolve4homegrown),intent(in) :: in_SS4HG    ! model control variables and previous function evaluation
-  type(var_dlength),intent(in) :: mpar_data                    ! model parameters
-  type(var_ilength),intent(in) :: indx_data                    ! indices defining model states and layers
-  type(var_dlength),intent(in) :: prog_data                    ! prognostic variables for a local HRU
-  real(rkind),intent(in)       :: rVec(:)                      ! residual vector (mixed units)
-  real(rkind),intent(in)       :: xInc(:)                      ! iteration increment (mixed units)
-  real(rkind),intent(in)       :: xVec(:)                      ! state vector (mixed units)
-  type(out_type_summaSolve4homegrown),intent(in) :: out_SS4HG  ! new function evaluation, convergence flag, and error control
-  ! locals
-  real(rkind),dimension(mSoil) :: psiScale                ! scaling factor for matric head
-  real(rkind),parameter        :: xSmall=1.e-0_rkind      ! a small offset
-  real(rkind),parameter        :: scalarTighten=0.1_rkind ! scaling factor for the scalar solution
-  real(rkind)                  :: soilWatbalErr           ! error in the soil water balance
-  real(rkind)                  :: canopy_max              ! absolute value of the residual in canopy water (kg m-2)
-  real(rkind),dimension(1)     :: energy_max              ! maximum absolute value of the energy residual (J m-3)
-  real(rkind),dimension(1)     :: liquid_max              ! maximum absolute value of the volumetric liquid water content residual (-)
-  real(rkind),dimension(1)     :: matric_max              ! maximum absolute value of the matric head iteration increment (m)
-  real(rkind)                  :: aquifer_max             ! absolute value of the residual in aquifer water (m)
-  logical(lgt)                 :: canopyConv              ! flag for canopy water balance convergence
-  logical(lgt)                 :: watbalConv              ! flag for soil water balance convergence
-  logical(lgt)                 :: liquidConv              ! flag for residual convergence
-  logical(lgt)                 :: matricConv              ! flag for matric head convergence
-  logical(lgt)                 :: energyConv              ! flag for energy convergence
-  logical(lgt)                 :: aquiferConv             ! flag for aquifer water balance convergence
-  ! -------------------------------------------------------------------------------------------------------------------------------------------------
-  ! association to variables in the data structures
-  associate(&
-   ! model control
-   iter                    => in_SS4HG % iter                                   ,& ! intent(in): iteration index
-   nsnow                   => in_SS4HG % nsnow                                  ,& ! intent(in): number of snow layers
-   scalarSolution          => in_SS4HG % scalarSolution                         ,& ! intent(in): flag to denote if implementing the scalar solution
-   ! convergence parameters
-   absConvTol_liquid       => mpar_data%var(iLookPARAM%absConvTol_liquid)%dat(1),&  ! intent(in): [dp] absolute convergence tolerance for vol frac liq water (-)
-   absConvTol_matric       => mpar_data%var(iLookPARAM%absConvTol_matric)%dat(1),&  ! intent(in): [dp] absolute convergence tolerance for matric head        (m)
-   absConvTol_energy       => mpar_data%var(iLookPARAM%absConvTol_energy)%dat(1),&  ! intent(in): [dp] absolute convergence tolerance for energy             (J m-3)
-   ! layer depth
-   mLayerDepth             => prog_data%var(iLookPROG%mLayerDepth)%dat          ,&  ! intent(in): [dp(:)] depth of each layer in the snow-soil sub-domain (m)
-   ! model indices
-   ixAqWat                 => indx_data%var(iLookINDEX%ixAqWat)%dat(1)          ,&  ! intent(in): [i4b]    index of aquifer storage state variable
-   ixCasNrg                => indx_data%var(iLookINDEX%ixCasNrg)%dat(1)         ,&  ! intent(in): [i4b]    index of canopy air space energy state variable
-   ixVegNrg                => indx_data%var(iLookINDEX%ixVegNrg)%dat(1)         ,&  ! intent(in): [i4b]    index of canopy energy state variable
-   ixVegHyd                => indx_data%var(iLookINDEX%ixVegHyd)%dat(1)         ,&  ! intent(in): [i4b]    index of canopy hydrology state variable (mass)
-   ixNrgOnly               => indx_data%var(iLookINDEX%ixNrgOnly)%dat           ,&  ! intent(in): [i4b(:)] list of indices for all energy states
-   ixHydOnly               => indx_data%var(iLookINDEX%ixHydOnly)%dat           ,&  ! intent(in): [i4b(:)] list of indices for all hydrology states
-   ixMatOnly               => indx_data%var(iLookINDEX%ixMatOnly)%dat           ,&  ! intent(in): [i4b(:)] list of indices for matric head state variables in the state vector
-   ixMatricHead            => indx_data%var(iLookINDEX%ixMatricHead)%dat        ,&  ! intent(in): [i4b(:)] list of indices for matric head in the soil vector
-   fnew                    => out_SS4HG % fnew                                   &  ! intent(in): [dp] new function evaluations
-  &) 
-
-   ! check convergence based on the canopy water balance
-   if (ixVegHyd/=integerMissing) then
-    canopy_max = real(abs(rVec(ixVegHyd)), rkind)*iden_water
-    canopyConv = (canopy_max    < absConvTol_liquid)  ! absolute error in canopy water balance (mm)
-   else
-    canopy_max = realMissing
-    canopyConv = .true.
-   end if
-
-   ! check convergence based on the residuals for energy (J m-3)
-   if (size(ixNrgOnly)>0) then
-    energy_max = real(maxval(abs( rVec(ixNrgOnly) )), rkind)
-    energyConv = (energy_max(1) < absConvTol_energy)  ! (based on the residual)
-   else
-    energy_max = realMissing
-    energyConv = .true.
-   end if
-
-   ! check convergence based on the residuals for volumetric liquid water content (-)
-   if (size(ixHydOnly)>0) then
-    liquid_max = real(maxval(abs( rVec(ixHydOnly) ) ), rkind)
-    ! (tighter convergence for the scalar solution)
-    if (scalarSolution) then
-     liquidConv = (liquid_max(1) < absConvTol_liquid*scalarTighten)   ! (based on the residual)
-    else
-     liquidConv = (liquid_max(1) < absConvTol_liquid)                 ! (based on the residual)
-    end if
-   else
-    liquid_max = realMissing
-    liquidConv = .true.
-   end if
-
-   ! check convergence based on the iteration increment for matric head
-   ! NOTE: scale by matric head to avoid unnecessairly tight convergence when there is no water
-   if (size(ixMatOnly)>0) then
-    psiScale   = abs( xVec(ixMatOnly) ) + xSmall ! avoid divide by zero
-    matric_max = maxval(abs( xInc(ixMatOnly)/psiScale ) )
-    matricConv = (matric_max(1) < absConvTol_matric)  ! NOTE: based on iteration increment
-   else
-    matric_max = realMissing
-    matricConv = .true.
-   end if
-
-   ! check convergence based on the soil water balance error (m)
-   if (size(ixMatOnly)>0) then
-    soilWatBalErr = sum( real(rVec(ixMatOnly), rkind)*mLayerDepth(nSnow+ixMatricHead) )
-    watbalConv    = (abs(soilWatbalErr) < absConvTol_liquid)  ! absolute error in total soil water balance (m)
-   else
-    soilWatbalErr = realMissing
-    watbalConv    = .true.
-   end if
-
-   ! check convergence based on the aquifer storage
-   if (ixAqWat/=integerMissing) then
-    aquifer_max = real(abs(rVec(ixAqWat)), rkind)*iden_water
-    aquiferConv = (aquifer_max    < absConvTol_liquid)  ! absolute error in aquifer water balance (mm)
-   else
-    aquifer_max = realMissing
-    aquiferConv = .true.
-   end if
-
-   ! final convergence check
-   checkConv = (canopyConv .and. watbalConv .and. matricConv .and. liquidConv .and. energyConv .and. aquiferConv)
-
-   ! print progress towards solution
-   if (globalPrintFlag) then
-    write(*,'(a,1x,i4,1x,7(e15.5,1x),7(L1,1x))') 'check convergence: ', iter, &
-     fnew, matric_max(1), liquid_max(1), energy_max(1), canopy_max, aquifer_max, soilWatBalErr, matricConv, liquidConv, energyConv, watbalConv, canopyConv, aquiferConv, watbalConv
-   end if
-
-  end associate ! end associations with variables in the data structures
-
- end function checkConv
-
- ! *********************************************************************************************************
  ! * module subroutine trustRegionRefinement: refine the iteration increment using trust regions
  ! *********************************************************************************************************
  subroutine trustRegionRefinement(in_TRR,in_SS4HG,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,stateVecNew,fluxVecNew,resVecNew,out_TRR)
@@ -1155,5 +1023,137 @@ contains
   if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
  
  end subroutine eval8summa_wrapper
+
+ ! *********************************************************************************************************
+ ! module function checkConv: check convergence based on the residual vector
+ ! *********************************************************************************************************
+ function checkConv(mSoil,in_SS4HG,mpar_data,indx_data,prog_data,rVec,xInc,xVec,out_SS4HG)
+  implicit none
+  ! result
+  logical(lgt)                 :: checkConv                    ! flag to denote convergence
+  ! dummies
+  integer(i4b),intent(in)      :: mSoil                        ! number of soil layers in solution vector
+  type(in_type_summaSolve4homegrown),intent(in) :: in_SS4HG    ! model control variables and previous function evaluation
+  type(var_dlength),intent(in) :: mpar_data                    ! model parameters
+  type(var_ilength),intent(in) :: indx_data                    ! indices defining model states and layers
+  type(var_dlength),intent(in) :: prog_data                    ! prognostic variables for a local HRU
+  real(rkind),intent(in)       :: rVec(:)                      ! residual vector (mixed units)
+  real(rkind),intent(in)       :: xInc(:)                      ! iteration increment (mixed units)
+  real(rkind),intent(in)       :: xVec(:)                      ! state vector (mixed units)
+  type(out_type_summaSolve4homegrown),intent(in) :: out_SS4HG  ! new function evaluation, convergence flag, and error control
+  ! locals
+  real(rkind),dimension(mSoil) :: psiScale                ! scaling factor for matric head
+  real(rkind),parameter        :: xSmall=1.e-0_rkind      ! a small offset
+  real(rkind),parameter        :: scalarTighten=0.1_rkind ! scaling factor for the scalar solution
+  real(rkind)                  :: soilWatbalErr           ! error in the soil water balance
+  real(rkind)                  :: canopy_max              ! absolute value of the residual in canopy water (kg m-2)
+  real(rkind),dimension(1)     :: energy_max              ! maximum absolute value of the energy residual (J m-3)
+  real(rkind),dimension(1)     :: liquid_max              ! maximum absolute value of the volumetric liquid water content residual (-)
+  real(rkind),dimension(1)     :: matric_max              ! maximum absolute value of the matric head iteration increment (m)
+  real(rkind)                  :: aquifer_max             ! absolute value of the residual in aquifer water (m)
+  logical(lgt)                 :: canopyConv              ! flag for canopy water balance convergence
+  logical(lgt)                 :: watbalConv              ! flag for soil water balance convergence
+  logical(lgt)                 :: liquidConv              ! flag for residual convergence
+  logical(lgt)                 :: matricConv              ! flag for matric head convergence
+  logical(lgt)                 :: energyConv              ! flag for energy convergence
+  logical(lgt)                 :: aquiferConv             ! flag for aquifer water balance convergence
+  ! -------------------------------------------------------------------------------------------------------------------------------------------------
+  ! association to variables in the data structures
+  associate(&
+   ! model control
+   iter                    => in_SS4HG % iter                                   ,& ! intent(in): iteration index
+   nsnow                   => in_SS4HG % nsnow                                  ,& ! intent(in): number of snow layers
+   scalarSolution          => in_SS4HG % scalarSolution                         ,& ! intent(in): flag to denote if implementing the scalar solution
+   ! convergence parameters
+   absConvTol_liquid       => mpar_data%var(iLookPARAM%absConvTol_liquid)%dat(1),&  ! intent(in): [dp] absolute convergence tolerance for vol frac liq water (-)
+   absConvTol_matric       => mpar_data%var(iLookPARAM%absConvTol_matric)%dat(1),&  ! intent(in): [dp] absolute convergence tolerance for matric head        (m)
+   absConvTol_energy       => mpar_data%var(iLookPARAM%absConvTol_energy)%dat(1),&  ! intent(in): [dp] absolute convergence tolerance for energy             (J m-3)
+   ! layer depth
+   mLayerDepth             => prog_data%var(iLookPROG%mLayerDepth)%dat          ,&  ! intent(in): [dp(:)] depth of each layer in the snow-soil sub-domain (m)
+   ! model indices
+   ixAqWat                 => indx_data%var(iLookINDEX%ixAqWat)%dat(1)          ,&  ! intent(in): [i4b]    index of aquifer storage state variable
+   ixCasNrg                => indx_data%var(iLookINDEX%ixCasNrg)%dat(1)         ,&  ! intent(in): [i4b]    index of canopy air space energy state variable
+   ixVegNrg                => indx_data%var(iLookINDEX%ixVegNrg)%dat(1)         ,&  ! intent(in): [i4b]    index of canopy energy state variable
+   ixVegHyd                => indx_data%var(iLookINDEX%ixVegHyd)%dat(1)         ,&  ! intent(in): [i4b]    index of canopy hydrology state variable (mass)
+   ixNrgOnly               => indx_data%var(iLookINDEX%ixNrgOnly)%dat           ,&  ! intent(in): [i4b(:)] list of indices for all energy states
+   ixHydOnly               => indx_data%var(iLookINDEX%ixHydOnly)%dat           ,&  ! intent(in): [i4b(:)] list of indices for all hydrology states
+   ixMatOnly               => indx_data%var(iLookINDEX%ixMatOnly)%dat           ,&  ! intent(in): [i4b(:)] list of indices for matric head state variables in the state vector
+   ixMatricHead            => indx_data%var(iLookINDEX%ixMatricHead)%dat        ,&  ! intent(in): [i4b(:)] list of indices for matric head in the soil vector
+   fnew                    => out_SS4HG % fnew                                   &  ! intent(in): [dp] new function evaluations
+  &) 
+
+   ! check convergence based on the canopy water balance
+   if (ixVegHyd/=integerMissing) then
+    canopy_max = real(abs(rVec(ixVegHyd)), rkind)*iden_water
+    canopyConv = (canopy_max    < absConvTol_liquid)  ! absolute error in canopy water balance (mm)
+   else
+    canopy_max = realMissing
+    canopyConv = .true.
+   end if
+
+   ! check convergence based on the residuals for energy (J m-3)
+   if (size(ixNrgOnly)>0) then
+    energy_max = real(maxval(abs( rVec(ixNrgOnly) )), rkind)
+    energyConv = (energy_max(1) < absConvTol_energy)  ! (based on the residual)
+   else
+    energy_max = realMissing
+    energyConv = .true.
+   end if
+
+   ! check convergence based on the residuals for volumetric liquid water content (-)
+   if (size(ixHydOnly)>0) then
+    liquid_max = real(maxval(abs( rVec(ixHydOnly) ) ), rkind)
+    ! (tighter convergence for the scalar solution)
+    if (scalarSolution) then
+     liquidConv = (liquid_max(1) < absConvTol_liquid*scalarTighten)   ! (based on the residual)
+    else
+     liquidConv = (liquid_max(1) < absConvTol_liquid)                 ! (based on the residual)
+    end if
+   else
+    liquid_max = realMissing
+    liquidConv = .true.
+   end if
+
+   ! check convergence based on the iteration increment for matric head
+   ! NOTE: scale by matric head to avoid unnecessairly tight convergence when there is no water
+   if (size(ixMatOnly)>0) then
+    psiScale   = abs( xVec(ixMatOnly) ) + xSmall ! avoid divide by zero
+    matric_max = maxval(abs( xInc(ixMatOnly)/psiScale ) )
+    matricConv = (matric_max(1) < absConvTol_matric)  ! NOTE: based on iteration increment
+   else
+    matric_max = realMissing
+    matricConv = .true.
+   end if
+
+   ! check convergence based on the soil water balance error (m)
+   if (size(ixMatOnly)>0) then
+    soilWatBalErr = sum( real(rVec(ixMatOnly), rkind)*mLayerDepth(nSnow+ixMatricHead) )
+    watbalConv    = (abs(soilWatbalErr) < absConvTol_liquid)  ! absolute error in total soil water balance (m)
+   else
+    soilWatbalErr = realMissing
+    watbalConv    = .true.
+   end if
+
+   ! check convergence based on the aquifer storage
+   if (ixAqWat/=integerMissing) then
+    aquifer_max = real(abs(rVec(ixAqWat)), rkind)*iden_water
+    aquiferConv = (aquifer_max    < absConvTol_liquid)  ! absolute error in aquifer water balance (mm)
+   else
+    aquifer_max = realMissing
+    aquiferConv = .true.
+   end if
+
+   ! final convergence check
+   checkConv = (canopyConv .and. watbalConv .and. matricConv .and. liquidConv .and. energyConv .and. aquiferConv)
+
+   ! print progress towards solution
+   if (globalPrintFlag) then
+    write(*,'(a,1x,i4,1x,7(e15.5,1x),7(L1,1x))') 'check convergence: ', iter, &
+     fnew, matric_max(1), liquid_max(1), energy_max(1), canopy_max, aquifer_max, soilWatBalErr, matricConv, liquidConv, energyConv, watbalConv, canopyConv, aquiferConv, watbalConv
+   end if
+
+  end associate ! end associations with variables in the data structures
+
+ end function checkConv
 
 end module summaSolve4homegrown_module

--- a/build/source/engine/summaSolve4homegrown.f90
+++ b/build/source/engine/summaSolve4homegrown.f90
@@ -352,7 +352,7 @@ contains
        call out_LSR % finalize(fNew,converged,err,cmessage)
       case(ixTrustRegion)
        call in_TRR % initialize(doRefine,fOld)
-       call trustRegionRefinement(in_TRR,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,stateVecNew,fluxVecNew,resVecNew,out_TRR)
+       call trustRegionRefinement(in_TRR,in_SS4HG,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,stateVecNew,fluxVecNew,resVecNew,out_TRR)
        call out_TRR % finalize(fNew,converged,err,cmessage)
       case default; err=20; message=trim(message)//'unable to identify numerical solution'; return_flag=.true.; return
      end select
@@ -582,82 +582,6 @@ contains
 
   end subroutine lineSearchRefinement
 
-
-  ! *********************************************************************************************************
-  ! * internal subroutine trustRegionRefinement: refine the iteration increment using trust regions
-  ! *********************************************************************************************************
-  subroutine trustRegionRefinement(in_TRR,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,stateVecNew,fluxVecNew,resVecNew,out_TRR)
-  ! provide access to the matrix routines
-  USE matrixOper_module, only: lapackSolv
-  USE matrixOper_module, only: computeGradient
-  implicit none
-  ! input
-  type(in_type_lineSearchRefinement),intent(in) :: in_TRR            ! object for scalar intent(in) arguments -- reusing line search class
-  real(rkind),intent(in)                        :: stateVecTrial(:)  ! trial state vector
-  real(rkind),intent(in)                        :: newtStepScaled(:) ! scaled newton step
-  real(rkind),intent(in)                        :: aJacScaled(:,:)   ! scaled jacobian matrix
-  real(rkind),intent(in)                        :: rVecScaled(:)     ! scaled residual vector
-  ! output
-  real(rkind),intent(out)                       :: stateVecNew(:)    ! new state vector
-  real(rkind),intent(out)                       :: fluxVecNew(:)     ! new flux vector
-  real(qp),intent(out)                          :: resVecNew(:)      ! NOTE: qp  ! new residual vector
-  type(out_type_lineSearchRefinement)           :: out_TRR           ! object for scalar intent(in) arguments -- reusing line search class
-  ! --------------------------------------------------------------------------------------------------------
-  ! local variables
-
-  ! .. needed ..
-
-  ! --------------------------------------------------------------------------------------------------------
-  associate(&
-   ! input
-   doTrustRefinement => in_TRR % doSearch          ,&    ! flag to refine using trust regions
-   fOld              => in_TRR % fOld              ,&    ! old function value
-   nState            => in_SS4HG % nState          ,&    ! total number of state variables
-   ! output
-   fNew      => out_TRR % fNew                     ,&    ! new function evaluation
-   converged => out_TRR % converged                ,&    ! convergence flag
-   err       => out_TRR % err                      ,&    ! error code
-   message   => out_TRR % message                   &    ! error message
-  &)
-
-   err=0; message='trustRegionRefinement/'
-   converged =.false.
-
-   ! check the need to refine the step
-   if (doTrustRefinement) then
-
-    ! (check vectors)
-    if (size(stateVecTrial)/=nState .or. size(newtStepScaled)/=nState .or. size(rVecScaled)/=nState)then
-     message=trim(message)//'unexpected size of input vectors'
-     err=20; return
-    end if
-
-    ! (check matrix)
-    if (size(aJacScaled,1)/=nState .or. size(aJacScaled,2)/=nState) then
-     message=trim(message)//'unexpected size of Jacobian matrix'
-     err=20; return
-    end if
-
-    ! dummy check for the function
-    if (fold==realMissing) print*, 'missing fold in trustRegionRefinement'
-
-    ! dummy
-    stateVecNew = realMissing
-    fluxVecNew  = realMissing
-    resVecNew   = quadMissing
-    fNew        = realMissing
-    converged   = .true.
-
-
-   end if  ! if doing the trust region refinement
-
-   message=trim(message)//'routine not implemented yet'
-   err=20; return
-
-  end associate
-
-  end subroutine trustRegionRefinement
-
  end subroutine summaSolve4homegrown
 
  ! *********************************************************************************************************
@@ -791,6 +715,82 @@ contains
   end associate ! end associations with variables in the data structures
 
  end function checkConv
+
+ ! *********************************************************************************************************
+ ! * module subroutine trustRegionRefinement: refine the iteration increment using trust regions
+ ! *********************************************************************************************************
+ subroutine trustRegionRefinement(in_TRR,in_SS4HG,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,stateVecNew,fluxVecNew,resVecNew,out_TRR)
+  ! provide access to the matrix routines
+  USE matrixOper_module, only: lapackSolv
+  USE matrixOper_module, only: computeGradient
+  implicit none
+  ! input
+  type(in_type_lineSearchRefinement),intent(in) :: in_TRR            ! object for scalar intent(in) arguments -- reusing line search class
+  type(in_type_summaSolve4homegrown),intent(in) :: in_SS4HG          ! model control variables and previous function evaluation
+  real(rkind),intent(in)                        :: stateVecTrial(:)  ! trial state vector
+  real(rkind),intent(in)                        :: newtStepScaled(:) ! scaled newton step
+  real(rkind),intent(in)                        :: aJacScaled(:,:)   ! scaled jacobian matrix
+  real(rkind),intent(in)                        :: rVecScaled(:)     ! scaled residual vector
+  ! output
+  real(rkind),intent(out)                       :: stateVecNew(:)    ! new state vector
+  real(rkind),intent(out)                       :: fluxVecNew(:)     ! new flux vector
+  real(qp),intent(out)                          :: resVecNew(:)      ! NOTE: qp  ! new residual vector
+  type(out_type_lineSearchRefinement)           :: out_TRR           ! object for scalar intent(in) arguments -- reusing line search class
+  ! --------------------------------------------------------------------------------------------------------
+  ! local variables
+
+  ! .. needed ..
+
+  ! --------------------------------------------------------------------------------------------------------
+  associate(&
+   ! input
+   doTrustRefinement => in_TRR % doSearch ,&    ! flag to refine using trust regions
+   fOld              => in_TRR % fOld     ,&    ! old function value
+   nState            => in_SS4HG % nState ,&    ! total number of state variables
+   ! output
+   fNew      => out_TRR % fNew            ,&    ! new function evaluation
+   converged => out_TRR % converged       ,&    ! convergence flag
+   err       => out_TRR % err             ,&    ! error code
+   message   => out_TRR % message          &    ! error message
+  &)
+
+   err=0; message='trustRegionRefinement/'
+   converged =.false.
+
+   ! check the need to refine the step
+   if (doTrustRefinement) then
+
+    ! check vectors
+    if (size(stateVecTrial)/=nState .or. size(newtStepScaled)/=nState .or. size(rVecScaled)/=nState)then
+     message=trim(message)//'unexpected size of input vectors'
+     err=20; return
+    end if
+
+    ! check matrix
+    if (size(aJacScaled,1)/=nState .or. size(aJacScaled,2)/=nState) then
+     message=trim(message)//'unexpected size of Jacobian matrix'
+     err=20; return
+    end if
+
+    ! dummy check for the function
+    if (fold==realMissing) print*, 'missing fold in trustRegionRefinement'
+
+    ! dummy
+    stateVecNew = realMissing
+    fluxVecNew  = realMissing
+    resVecNew   = quadMissing
+    fNew        = realMissing
+    converged   = .true.
+
+
+   end if  ! if doing the trust region refinement
+
+   message=trim(message)//'routine not implemented yet'
+   err=20; return
+
+  end associate
+
+ end subroutine trustRegionRefinement
 
  ! *********************************************************************************************************
  ! * module subroutine safeRootfinder: refine the 1-d iteration increment using brackets

--- a/build/source/engine/summaSolve4homegrown.f90
+++ b/build/source/engine/summaSolve4homegrown.f90
@@ -368,7 +368,11 @@ contains
   
     ! * case 2: scalar
     else
-     call safeRootfinder(stateVecTrial,rVecScaled,newtStepScaled,stateVecNew,fluxVecNew,resVecNew,out_SRF)
+     call safeRootfinder(mSoil,stateVecTrial,rVecScaled,newtStepScaled,fScale,xScale,&
+                        &in_SS4HG,model_decisions,lookup_data,type_data,attr_data,&
+                        &mpar_data,forc_data,bvar_data,prog_data,&
+                        &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
+                        &out_SS4HG,stateVecNew,fluxVecNew,resSinkNew,resVecNew,out_SRF)
      call out_SRF % finalize(fNew,converged,err,cmessage)
      if (err/=0) then; message=trim(message)//trim(cmessage); return_flag=.true.; return; end if  ! check for errors
     end if
@@ -654,133 +658,6 @@ contains
 
   end subroutine trustRegionRefinement
 
-
-  ! *********************************************************************************************************
-  ! * internal subroutine safeRootfinder: refine the 1-d iteration increment using brackets
-  ! *********************************************************************************************************
-  subroutine safeRootfinder(stateVecTrial,rVecscaled,newtStepScaled,stateVecNew,fluxVecNew,resVecNew,out_SRF)
-  USE,intrinsic :: ieee_arithmetic,only:ieee_is_nan          ! IEEE arithmetic (check NaN)
-  USE globalData,only:dNaN                                   ! double precision NaN
-  implicit none
-  ! input
-  real(rkind),intent(in)         :: stateVecTrial(:)         ! trial state vector
-  real(rkind),intent(in)         :: rVecScaled(:)            ! scaled residual vector
-  real(rkind),intent(in)         :: newtStepScaled(:)        ! scaled newton step
-  ! output
-  real(rkind),intent(out)        :: stateVecNew(:)           ! new state vector
-  real(rkind),intent(out)        :: fluxVecNew(:)            ! new flux vector
-  real(qp),intent(out)           :: resVecNew(:) ! NOTE: qp  ! new residual vector
-  type(out_type_lineSearchRefinement),intent(out) :: out_SRF ! object for scalar intent(out) arguments (reusing lineSearchRefinement class)
-  ! --------------------------------------------------------------------------------------------------------
-  ! local variables
-  character(len=256)             :: cmessage                 ! error message of downwind routine
-  real(rkind),parameter          :: relTolerance=0.005_rkind ! force bi-section if trial is slightly larger than (smaller than) xmin (xmax)
-  real(rkind)                    :: xTolerance               ! relTolerance*(xmax-xmin)
-  real(rkind)                    :: xInc(in_SS4HG % nState)  ! iteration increment (re-scaled to original units of the state vector)
-  real(rkind)                    :: rVec(in_SS4HG % nState)  ! residual vector (re-scaled to original units of the state equation)
-  logical(lgt)                   :: feasible                 ! feasibility of the solution
-  logical(lgt)                   :: doBisection              ! flag to do the bi-section
-  logical(lgt)                   :: bracketsDefined          ! flag to define if the brackets are defined
-  integer(i4b),parameter         :: nCheck=100               ! number of times to check the model state variables
-  real(rkind),parameter          :: delX=1._rkind            ! trial increment
-  ! --------------------------------------------------------------------------------------------------------
-  associate(&
-   iter           => in_SS4HG % iter           ,& ! intent(in): iteration index
-   nSnow          => in_SS4HG % nSnow          ,& ! intent(in): number of snow layers
-   nSoil          => in_SS4HG % nSoil          ,& ! intent(in): number of soil layers
-   nState         => in_SS4HG % nState         ,& ! intent(in): total number of state
-   xMin           => io_SS4HG % xMin           ,& ! intent(inout): bracket of the root   
-   xMax           => io_SS4HG % xMax           ,& ! intent(inout): bracket of the root  
-   fNew           => out_SRF % fNew            ,& ! intent(out): new function evaluation
-   converged      => out_SRF % converged       ,& ! intent(out): convergence flag
-   err            => out_SRF % err             ,& ! intent(out): error code
-   message        => out_SRF % message          & ! intent(out): error message
-  &)
-
-   err=0; message='safeRootfinder/'
-   converged = .false.
-
-   ! check scalar
-   if (size(stateVecTrial)/=1 .or. size(rVecScaled)/=1 .or. size(newtStepScaled)/=1) then
-    message=trim(message)//'unexpected size of input vectors'
-    err=20; return
-   end if
-
-   ! initialize brackets to rkind precision NaN
-   if (iter==1) then
-    xMax = dNaN
-    xMin = dNaN
-   end if
-
-   ! get the residual vector
-   rVec = real(rVecScaled, rkind)*real(fScale, rkind)
-
-   ! update brackets
-   if (rVec(1)<0._rkind) then
-    xMin = stateVecTrial(1)
-   else
-    xMax = stateVecTrial(1)
-   end if
-
-   ! get the iteration increment
-   xInc = newtStepScaled*xScale
-
-   ! *****
-   ! * case 1: the iteration increment is the same sign as the residual vector
-   if (xInc(1)*rVec(1) > 0._rkind) then
-
-    ! get brackets if they do not exist
-    if ( ieee_is_nan(xMin) .or. ieee_is_nan(xMax) ) then
-     call getBrackets(stateVecTrial,rvec,fScale,in_SS4HG,model_decisions,lookup_data,type_data,attr_data,&
-                     &mpar_data,forc_data,bvar_data,prog_data,&
-                     &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
-                     &out_SS4HG,stateVecNew,fluxVecNew,resSinkNew,resVecNew,xMin,xMax,err,cmessage)
-     if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
-    end if
-
-    ! use bi-section
-    stateVecNew(1) = 0.5_rkind*(xMin + xMax)
-
-   ! *****
-   ! * case 2: the iteration increment is the correct sign
-   else
-
-    ! state vector with proposed iteration increment
-    stateVecNew = stateVecTrial + xInc
-     
-    ! impose solution constraints adjusting state vector and iteration increment
-    call imposeConstraints(model_decisions,indx_data,prog_data,mpar_data,stateVecNew,stateVecTrial,nState,nSoil,nSnow,cmessage,err)
-    if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
-    xInc = stateVecNew - stateVecTrial
-
-   end if  ! if the iteration increment is the same sign as the residual vector
-
-   ! bi-section
-   bracketsDefined = ( .not.ieee_is_nan(xMin) .and. .not.ieee_is_nan(xMax) )  ! check that the brackets are defined
-   if (bracketsDefined) then
-    xTolerance  = relTolerance*(xMax-xMin)
-    doBisection = (stateVecNew(1)<xMin+xTolerance .or. stateVecNew(1)>xMax-xTolerance)
-    if (doBisection) stateVecNew(1) = 0.5_rkind*(xMin+xMax)
-   end if
-
-   ! evaluate summa
-   call eval8summa_wrapper(stateVecNew,fScale,in_SS4HG,model_decisions,&
-                          &lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
-                          &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
-                          &fluxVecNew,resSinkNew,resVecNew,fNew,feasible,err,cmessage)
-   if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
-
-   ! check feasibility (should be feasible because of the call to imposeConstraints, except if canopyTemp>canopyTempMax (500._rkind)) 
-   if (.not.feasible) then; err=20; message=trim(message)//'state vector not feasible'; return; end if
-
-   ! check convergence
-   converged = checkConv(mSoil,in_SS4HG,mpar_data,indx_data,prog_data,resVecNew,xInc,stateVecNew,out_SS4HG)
-
-  end associate
-
-  end subroutine safeRootfinder
-
-
  end subroutine summaSolve4homegrown
 
  ! *********************************************************************************************************
@@ -916,9 +793,161 @@ contains
  end function checkConv
 
  ! *********************************************************************************************************
+ ! * module subroutine safeRootfinder: refine the 1-d iteration increment using brackets
+ ! *********************************************************************************************************
+ subroutine safeRootfinder(mSoil,stateVecTrial,rVecscaled,newtStepScaled,fScale,xScale,&
+                          &in_SS4HG,model_decisions,lookup_data,type_data,attr_data,&
+                          &mpar_data,forc_data,bvar_data,prog_data,&
+                          &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
+                          &out_SS4HG,stateVecNew,fluxVecNew,resSinkNew,resVecNew,out_SRF)
+  USE,intrinsic :: ieee_arithmetic,only:ieee_is_nan            ! IEEE arithmetic (check NaN)
+  USE eval8summa_module,only: imposeConstraints                ! imposeConstraints
+  USE globalData,only:dNaN                                     ! double precision NaN
+  implicit none
+  ! input
+  integer(i4b),intent(in)         :: mSoil                     ! number of soil layers in solution vector
+  real(rkind),intent(in)          :: stateVecTrial(:)          ! trial state vector
+  real(rkind),intent(in)          :: rVecScaled(:)             ! scaled residual vector
+  real(rkind),intent(in)          :: newtStepScaled(:)         ! scaled newton step
+  real(rkind),intent(in)          :: fScale(:)                 ! characteristic scale of the function evaluations
+  real(rkind),intent(in)          :: xScale(:)                 ! characteristic scale of the state vector
+  type(in_type_summaSolve4homegrown),intent(in) :: in_SS4HG    ! model control variables and previous function evaluation
+  type(model_options),intent(in)  :: model_decisions(:)        ! model decisions
+  type(zLookup),      intent(in)  :: lookup_data               ! lookup tables
+  type(var_i),        intent(in)  :: type_data                 ! type of vegetation and soil
+  type(var_d),        intent(in)  :: attr_data                 ! spatial attributes
+  type(var_dlength),  intent(in)  :: mpar_data                 ! model parameters
+  type(var_d),        intent(in)  :: forc_data                 ! model forcing data
+  type(var_dlength),  intent(in)  :: bvar_data                 ! model variables for the local basin
+  type(var_dlength),  intent(in)  :: prog_data                 ! prognostic variables for a local HRU
+  ! input-output
+  real(qp),intent(inout)          :: sMul(:)   ! NOTE: qp      ! state vector multiplier (used in the residual calculations)
+  type(io_type_summaSolve4homegrown),intent(inout) :: io_SS4HG ! first flux call flag and baseflow variables
+  type(var_ilength),intent(inout) :: indx_data                 ! indices defining model states and layers
+  type(var_dlength),intent(inout) :: diag_data                 ! diagnostic variables for a local HRU
+  type(var_dlength),intent(inout) :: flux_data                 ! model fluxes for a local HRU
+  type(var_dlength),intent(inout) :: deriv_data                ! derivatives in model fluxes w.r.t. relevant state variables
+  real(rkind),intent(inout)       :: dBaseflow_dMatric(:,:)    ! derivative in baseflow w.r.t. matric head (s-1)
+  ! output
+  type(out_type_summaSolve4homegrown),intent(out) :: out_SS4HG ! new function evaluation, convergence flag, and error control
+  real(rkind),intent(out)         :: stateVecNew(:)            ! new state vector
+  real(rkind),intent(out)         :: fluxVecNew(:)             ! new flux vector
+  real(rkind),intent(out)         :: resSinkNew(:)             ! sink terms on the RHS of the flux equation
+  real(qp),intent(out)            :: resVecNew(:) ! NOTE: qp   ! new residual vector
+  type(out_type_lineSearchRefinement),intent(out) :: out_SRF   ! object for scalar intent(out) arguments (reusing lineSearchRefinement class)
+  ! --------------------------------------------------------------------------------------------------------
+  ! local variables
+  character(len=256)              :: cmessage                  ! error message of downwind routine
+  real(rkind),parameter           :: relTolerance=0.005_rkind  ! force bi-section if trial is slightly larger than (smaller than) xmin (xmax)
+  real(rkind)                     :: xTolerance                ! relTolerance*(xmax-xmin)
+  real(rkind)                     :: xInc(in_SS4HG % nState)   ! iteration increment (re-scaled to original units of the state vector)
+  real(rkind)                     :: rVec(in_SS4HG % nState)   ! residual vector (re-scaled to original units of the state equation)
+  logical(lgt)                    :: feasible                  ! feasibility of the solution
+  logical(lgt)                    :: doBisection               ! flag to do the bi-section
+  logical(lgt)                    :: bracketsDefined           ! flag to define if the brackets are defined
+  integer(i4b),parameter          :: nCheck=100                ! number of times to check the model state variables
+  real(rkind),parameter           :: delX=1._rkind             ! trial increment
+  ! --------------------------------------------------------------------------------------------------------
+  associate(&
+   iter           => in_SS4HG % iter           ,& ! intent(in): iteration index
+   nSnow          => in_SS4HG % nSnow          ,& ! intent(in): number of snow layers
+   nSoil          => in_SS4HG % nSoil          ,& ! intent(in): number of soil layers
+   nState         => in_SS4HG % nState         ,& ! intent(in): total number of state
+   xMin           => io_SS4HG % xMin           ,& ! intent(inout): bracket of the root   
+   xMax           => io_SS4HG % xMax           ,& ! intent(inout): bracket of the root  
+   fNew           => out_SRF % fNew            ,& ! intent(out): new function evaluation
+   converged      => out_SRF % converged       ,& ! intent(out): convergence flag
+   err            => out_SRF % err             ,& ! intent(out): error code
+   message        => out_SRF % message          & ! intent(out): error message
+  &)
+
+   err=0; message='safeRootfinder/'
+   converged = .false.
+
+   ! check scalar
+   if (size(stateVecTrial)/=1 .or. size(rVecScaled)/=1 .or. size(newtStepScaled)/=1) then
+    message=trim(message)//'unexpected size of input vectors'
+    err=20; return
+   end if
+
+   ! initialize brackets to rkind precision NaN
+   if (iter==1) then
+    xMax = dNaN
+    xMin = dNaN
+   end if
+
+   ! get the residual vector
+   rVec = real(rVecScaled, rkind)*real(fScale, rkind)
+
+   ! update brackets
+   if (rVec(1)<0._rkind) then
+    xMin = stateVecTrial(1)
+   else
+    xMax = stateVecTrial(1)
+   end if
+
+   ! get the iteration increment
+   xInc = newtStepScaled*xScale
+
+   ! *****
+   ! * case 1: the iteration increment is the same sign as the residual vector
+   if (xInc(1)*rVec(1) > 0._rkind) then
+
+    ! get brackets if they do not exist
+    if ( ieee_is_nan(xMin) .or. ieee_is_nan(xMax) ) then
+     call getBrackets(stateVecTrial,rVec,fScale,in_SS4HG,model_decisions,lookup_data,type_data,attr_data,&
+                     &mpar_data,forc_data,bvar_data,prog_data,&
+                     &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
+                     &out_SS4HG,stateVecNew,fluxVecNew,resSinkNew,resVecNew,xMin,xMax,err,cmessage)
+     if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
+    end if
+
+    ! use bi-section
+    stateVecNew(1) = 0.5_rkind*(xMin + xMax)
+
+   ! *****
+   ! * case 2: the iteration increment is the correct sign
+   else
+
+    ! state vector with proposed iteration increment
+    stateVecNew = stateVecTrial + xInc
+     
+    ! impose solution constraints adjusting state vector and iteration increment
+    call imposeConstraints(model_decisions,indx_data,prog_data,mpar_data,stateVecNew,stateVecTrial,nState,nSoil,nSnow,cmessage,err)
+    if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
+    xInc = stateVecNew - stateVecTrial
+
+   end if  ! if the iteration increment is the same sign as the residual vector
+
+   ! bi-section
+   bracketsDefined = ( .not.ieee_is_nan(xMin) .and. .not.ieee_is_nan(xMax) )  ! check that the brackets are defined
+   if (bracketsDefined) then
+    xTolerance  = relTolerance*(xMax-xMin)
+    doBisection = (stateVecNew(1)<xMin+xTolerance .or. stateVecNew(1)>xMax-xTolerance)
+    if (doBisection) stateVecNew(1) = 0.5_rkind*(xMin+xMax)
+   end if
+
+   ! evaluate summa
+   call eval8summa_wrapper(stateVecNew,fScale,in_SS4HG,model_decisions,&
+                          &lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,&
+                          &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
+                          &fluxVecNew,resSinkNew,resVecNew,fNew,feasible,err,cmessage)
+   if (err/=0) then; message=trim(message)//trim(cmessage); return; end if  ! check for errors
+
+   ! check feasibility (should be feasible because of the call to imposeConstraints, except if canopyTemp>canopyTempMax (500._rkind)) 
+   if (.not.feasible) then; err=20; message=trim(message)//'state vector not feasible'; return; end if
+
+   ! check convergence
+   converged = checkConv(mSoil,in_SS4HG,mpar_data,indx_data,prog_data,resVecNew,xInc,stateVecNew,out_SS4HG)
+
+  end associate
+
+ end subroutine safeRootfinder
+
+ ! *********************************************************************************************************
  ! * module subroutine getBrackets: get the brackets for safeRootfinder
  ! *********************************************************************************************************
- subroutine getBrackets(stateVecTrial,rvec,fScale,in_SS4HG,model_decisions,lookup_data,type_data,attr_data,&
+ subroutine getBrackets(stateVecTrial,rVec,fScale,in_SS4HG,model_decisions,lookup_data,type_data,attr_data,&
                        &mpar_data,forc_data,bvar_data,prog_data,&
                        &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&
                        &out_SS4HG,stateVecNew,fluxVecNew,resSinkNew,resVecNew,xMin,xMax,err,message)


### PR DESCRIPTION
Hi @ashleymedin - This is the final PR in the series for making Newton step refinement procedures externally accessible. As before, the idea is to have the option to apply the homegrown Newton step refinement method while using the external nested Newton solver. We would then be able to compare both solvers while using the same refinement approach.

This required transforming the `refine_Newton_step` internal subroutine into a module subroutine (i.e., moving the routine outside of the `contains` block `summaSolve4homgrown`). Of course, all procedures called within `refine_Newton_step` had to also be moved outside of `summaSolve4homgrown`. This was the case for `lineSearchRefinement` and `trustRegionRefinement`. 

I have also cleaned up the declarations within `summaSolve4homegrown_module` where possible.

This PR is structural in nature and does not impact run time, memory use, or output. This was confirmed using the test suite (with some addition runs for FUSE).
 
Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] Closes #xxx (identify the issue associated with this PR)
- [x] Code passes standard test cases (results are either bit-for-bit identical, or differences are explained in the PR comment)
- [ ] New tests added (describe which tests were performed to test the changes)
- [ ] Science test figures (add figures to PR comment and describe the tests)
- [ ] Checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] Describe the change in the release notes (use  `./summa/docs/whats-new.md`)