### PR TITLE
Correction to error control for `refine_Newton_step`

### DIFF
--- a/build/source/engine/summaSolve4homegrown.f90
+++ b/build/source/engine/summaSolve4homegrown.f90
@@ -244,7 +244,7 @@ contains
    call refine_Newton_step(in_SS4HG,mSoil,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,fScale,xScale,&         ! input
                           &model_decisions,lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,& ! input
                           &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&                ! input-output
-                          &stateVecNew,fluxVecNew,resSinkNew,resVecNew,out_SS4HG)                                    ! output
+                          &stateVecNew,fluxVecNew,resSinkNew,resVecNew,out_SS4HG,return_flag)                        ! output
    if (return_flag) return ! return if error
   end subroutine update_summaSolve4homegrown
 
@@ -343,7 +343,7 @@ contains
  subroutine refine_Newton_step(in_SS4HG,mSoil,stateVecTrial,newtStepScaled,aJacScaled,rVecScaled,fScale,xScale,&         ! input
                               &model_decisions,lookup_data,type_data,attr_data,mpar_data,forc_data,bvar_data,prog_data,& ! input
                               &sMul,io_SS4HG,indx_data,diag_data,flux_data,deriv_data,dBaseflow_dMatric,&                ! input-output
-                              &stateVecNew,fluxVecNew,resSinkNew,resVecNew,out_SS4HG)                                    ! output
+                              &stateVecNew,fluxVecNew,resSinkNew,resVecNew,out_SS4HG,return_flag)                        ! output
   ! provide access to the external procedures
   USE matrixOper_module, only: computeGradient
   USE eval8summa_module, only: imposeConstraints
@@ -379,18 +379,27 @@ contains
   real(rkind),intent(out)         :: resSinkNew(:)             ! sink terms on the RHS of the flux equation
   real(qp),intent(out)            :: resVecNew(:) ! NOTE: qp   ! new residual vector
   type(out_type_summaSolve4homegrown),intent(out) :: out_SS4HG ! new function evaluation, convergence flag, and error control
+  logical(lgt),intent(out)        :: return_flag               ! flag that controls execution of return statements
   ! local
   logical(lgt)                    :: doRefine                      ! flag for step refinement
   integer(i4b),parameter          :: ixLineSearch=1001             ! step refinement = line search
   integer(i4b),parameter          :: ixTrustRegion=1002            ! step refinement = trust region
   integer(i4b),parameter          :: ixStepRefinement=ixLineSearch ! decision for the numerical solution
-  logical(lgt)                    :: return_flag                   ! flag that controls execution of return statements
   character(LEN=256)              :: cmessage                      ! error message of downwind routine
   type(in_type_lineSearchRefinement)  :: in_LSR                    ! lineSearchRefinement
   type(out_type_lineSearchRefinement) :: out_LSR                   ! lineSearchRefinement 
   type(in_type_lineSearchRefinement)  :: in_TRR                    ! trustRegionRefinement
   type(out_type_lineSearchRefinement) :: out_TRR                   ! trustRegionRefinement
   type(out_type_lineSearchRefinement) :: out_SRF                   ! safeRootFinder
+
+  ! initialize error control
+  associate(&
+   err     => out_SS4HG % err      ,& 
+   message => out_SS4HG % message   &     
+  &)  
+   err=0; message='refine_Newton_step/'
+  end associate
+  return_flag = .false. ! initialize return flag (used to indicate non-recoverable errors)
  
   ! initialize the flag for step refinement
   doRefine=.true.


### PR DESCRIPTION
Hi @ashleymedin - This PR applies a correction to the error control for `refine_Newton_step`. It was found that the `return_flag` variable was not being updated within `summaSolve4homegrown` during the call to `refine_Newton_step`. To correct this, I have added `return_ flag` to the argument list for `refine_Newton_step`. With this update, non-recoverable errors within `refine_Newton_step` result in a `return` at the correct point within `summaSolve4homegrown`.

I have also updated the error message string so that errors in `refine_Newton_step` will show that routine name in the message.

My apologies for not catching this sooner. Details like these are not necessarily caught with the test suite because this error case does not occur. However, to be thorough the test suite was checked. Test suite output and resource use did not change. 

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] Closes #xxx (identify the issue associated with this PR)
- [x] Code passes standard test cases (results are either bit-for-bit identical, or differences are explained in the PR comment)
- [ ] New tests added (describe which tests were performed to test the changes)
- [ ] Science test figures (add figures to PR comment and describe the tests)
- [ ] Checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] Describe the change in the release notes (use  `./summa/docs/whats-new.md`)